### PR TITLE
Fix auth_status docstring

### DIFF
--- a/duo_client/auth.py
+++ b/duo_client/auth.py
@@ -163,7 +163,7 @@ class Auth(client.Client):
         """
         Longpoll for the status of an asynchronous authentication call.
 
-        Returns a tuple with four named fields:
+        Returns a dict with four items:
 
         * waiting: True if the authentication attempt is still in progress
           and the caller can continue to poll, else False.


### PR DESCRIPTION
The method doesn't return a collections.namedtuple instance, so it's not appropriate to say it returns "a tuple with named fields".
