### PR TITLE
Added support for HTTP proxy to splunk example

### DIFF
--- a/examples/splunk/duo.conf
+++ b/examples/splunk/duo.conf
@@ -7,3 +7,6 @@ skey =
 
 ; api-<hostname>
 host =
+
+; HTTP proxy support
+;http_proxy = http://host[:port]

--- a/examples/splunk/splunk.py
+++ b/examples/splunk/splunk.py
@@ -7,6 +7,9 @@ import time
 
 import duo_client
 
+# For proxy support
+from urlparse import urlparse
+
 
 class BaseLog(object):
 
@@ -192,12 +195,22 @@ def admin_api_from_config(config_path):
     ca_certs = config_d.get("ca_certs", None)
     if ca_certs is None:
         ca_certs = config_d.get("ca", None)
-    return duo_client.Admin(
+
+    ret = duo_client.Admin(
         ikey=config_d['ikey'],
         skey=config_d['skey'],
         host=config_d['host'],
         ca_certs=ca_certs,
     )
+
+    http_proxy = config_d.get("http_proxy", None)
+    if http_proxy is not None:
+        proxy_parsed = urlparse(http_proxy)
+        proxy_host = proxy_parsed.hostname
+        proxy_port = proxy_parsed.port
+        ret.set_proxy(host = proxy_host, port = proxy_port)
+
+    return ret
 
 
 def main():


### PR DESCRIPTION
To use, insert an http_proxy line in the duo.conf file

Committer: James Thomas james.thomas@fusionx.com

```
modified:   examples/splunk/duo.conf
modified:   examples/splunk/splunk.py
```
