### PR TITLE
Cleaner rpm build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include examples *
 include tests/*.py
 include README.md
 include duo_client/ca_certs.pem
+include requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [bdist_wheel]
 # The code is written to work on both Python 2 and Python 3.
 universal=1
+
+[bdist_rpm]
+requires=python-six
+build_requires=python-nose


### PR DESCRIPTION
The RPM names of the required packages are different than what they are in pypi (six vs python-six). This change allows for building an RPM with `python setup.py bdist_rpm` and having the RPM requirements be correct.

I'm not sure if this is the best way to resolve this--just how I did it. You may want to continue using `requirements.txt`.
