### PR TITLE
Add missing 'device' field in returned results doc

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -226,6 +226,7 @@ class Admin(client.Client):
                 {'timestamp': <int:unix timestamp>,
                  'eventtype': "authentication",
                  'host': <str:host>,
+                 'device': <str:device>,
                  'username': <str:username>,
                  'factor': <str:factor>,
                  'result': <str:result>,


### PR DESCRIPTION
Initially I overlooked that 'device' was even returned as the output from help(get_authentication_log) had it omitted. This helps make sure that it doesn't happen to anybody else.