### PR TITLE
Add release to bdist_rpm, issue #37

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,5 +3,6 @@
 universal=1
 
 [bdist_rpm]
+release = 1%{?dist}
 requires=python-six
 build_requires=python-nose


### PR DESCRIPTION
[Docs](http://python-rpm-porting.readthedocs.io/en/latest/application-modules.html) indicate this should be portable across py2 and py3, and [is needed](https://fedoraproject.org/wiki/Packaging:DistTag) for RPMifying.