### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ install:
     - pip install -r requirements-dev.txt
 script:
     - nose2
+matrix:
+  allow_failures:
+    - python: 3.7-dev


### PR DESCRIPTION
Added Python 2.6 to the build matrix.
Allowed Python 3.7 to fail without tanking all of Travis. Before 3.7 is released we will want to fix the issues and remove it from the exception list.