### PR TITLE
Add v2 group detail Admin API methods and associated tests

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import unittest
+import warnings
 from . import util
 import duo_client.admin
 
@@ -180,6 +181,84 @@ class TestAdmin(unittest.TestCase):
         self.assertEqual(uri, '/admin/v1/bypass_codes/DU012345678901234567')
         self.assertEqual(util.params_to_dict(args),
                          {'account_id': [self.client.account_id]})
+
+    def test_get_groups(self):
+        """ Test for getting list of all groups
+        """
+        response = self.client.get_groups()
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/groups')
+        self.assertEqual(util.params_to_dict(args),
+                         {'account_id': [self.client.account_id]})
+
+    def test_get_group_v1(self):
+        """ Test for v1 API of getting specific group details
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            response = self.client.get_group('ABC123', api_version=1)
+            uri, args = response['uri'].split('?')
+
+            # Assert deprecation warning generated
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn('Please migrate to the v2 API', str(w[0].message))
+
+            self.assertEqual(response['method'], 'GET')
+            self.assertEqual(uri, '/admin/v1/groups/ABC123')
+            self.assertEqual(util.params_to_dict(args),
+                             {'account_id': [self.client.account_id]})
+
+    def test_get_group_v2(self):
+        """ Test for v2 API of getting specific group details
+        """
+        response = self.client.get_group('ABC123', api_version=2)
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/groups/ABC123')
+        self.assertEqual(util.params_to_dict(args),
+                         {'account_id': [self.client.account_id]})
+
+    def test_get_group_users(self):
+        """ Test for getting list of users associated with a group
+        """
+        response = self.client.get_group_users('ABC123')
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/groups/ABC123/users')
+        self.assertEqual(
+            util.params_to_dict(args),
+            {
+                'account_id': [self.client.account_id],
+                'limit': ['100'],
+                'offset': ['0'],
+            })
+
+    def test_delete_group(self):
+        """ Test for deleting a group
+        """
+        response = self.client.delete_group('ABC123')
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'DELETE')
+        self.assertEqual(uri, '/admin/v1/groups/ABC123')
+        self.assertEqual(util.params_to_dict(args),
+                         {'account_id': [self.client.account_id]})
+
+    def test_modify_group(self):
+        """ Test for modifying a group
+        """
+        response = self.client.modify_group('ABC123')
+        self.assertEqual(response['method'], 'POST')
+        self.assertEqual(response['uri'], '/admin/v1/groups/ABC123')
+        self.assertEqual(util.params_to_dict(response['body']),
+                         {'account_id': [self.client.account_id]})
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add methods for v2 API for getting group details
- Add deprecation warning for v1 API for getting group details
- Adds associated tests for groups adminapi methods
- Normalize "gkey" param name to "group_id"