### PR TITLE
Add alias1-alias4 to add_user and update_user

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -482,7 +482,8 @@ class Admin(client.Client):
         return response
 
     def add_user(self, username, realname=None, status=None,
-                 notes=None, email=None, firstname=None, lastname=None):
+                 notes=None, email=None, firstname=None, lastname=None,
+                 alias1=None, alias2=None, alias3=None, alias4=None):
         """
         Adds a user.
 
@@ -493,6 +494,7 @@ class Admin(client.Client):
         email - Email address (optional)
         firstname - User's given name for ID Proofing (optional)
         lastname - User's surname for ID Proofing (optional)
+        alias1..alias4 - Aliases for the user's primary username (optional)
 
         Returns newly created user object.
 
@@ -513,14 +515,22 @@ class Admin(client.Client):
             params['firstname'] = firstname
         if lastname is not None:
             params['lastname'] = lastname
+        if alias1 is not None:
+            params['alias1'] = alias1
+        if alias2 is not None:
+            params['alias2'] = alias2
+        if alias3 is not None:
+            params['alias3'] = alias3
+        if alias4 is not None:
+            params['alias4'] = alias4
         response = self.json_api_call('POST',
                                       '/admin/v1/users',
                                       params)
         return response
 
-    def update_user(self, user_id, username=None, realname=None,
-                    status=None, notes=None, email=None, firstname=None,
-                    lastname=None):
+    def update_user(self, user_id, username=None, realname=None, status=None,
+                    notes=None, email=None, firstname=None, lastname=None,
+                    alias1=None, alias2=None, alias3=None, alias4=None):
         """
         Update username, realname, status, or notes for a user.
 
@@ -554,6 +564,14 @@ class Admin(client.Client):
             params['firstname'] = firstname
         if lastname is not None:
             params['lastname'] = lastname
+        if alias1 is not None:
+            params['alias1'] = alias1
+        if alias2 is not None:
+            params['alias2'] = alias2
+        if alias3 is not None:
+            params['alias3'] = alias3
+        if alias4 is not None:
+            params['alias4'] = alias4
         response = self.json_api_call('POST', path, params)
         return response
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -63,19 +63,28 @@ class TestAdmin(unittest.TestCase):
     # POST with params
     def test_add_user(self):
         # all params given
-        response = self.client.add_user('foo', 'bar', 'active', 'notes', 'foobar@baz.com', 'fName', 'lName')
+        response = self.client.add_user(
+            'foo', realname='bar', status='active', notes='notes',
+            email='foobar@baz.com', firstname='fName', lastname='lName',
+            alias1='alias1', alias2='alias2', alias3='alias3', alias4='alias4')
         self.assertEqual(response['method'], 'POST')
         self.assertEqual(response['uri'], '/admin/v1/users')
         self.assertEqual(
             util.params_to_dict(response['body']),
-            {'realname':['bar'],
-             'notes':['notes'],
-             'username':['foo'],
-             'status':['active'],
-             'email':['foobar%40baz.com'],
-             'firstname':['fName'],
-             'lastname':['lName'],
-             'account_id':[self.client.account_id]})
+            {
+                'realname': ['bar'],
+                'notes': ['notes'],
+                'username': ['foo'],
+                'status': ['active'],
+                'email': ['foobar%40baz.com'],
+                'firstname': ['fName'],
+                'lastname': ['lName'],
+                'account_id': [self.client.account_id],
+                'alias1': ['alias1'],
+                'alias2': ['alias2'],
+                'alias3': ['alias3'],
+                'alias4': ['alias4'],
+            })
         # defaults
         response = self.client.add_user('bar')
         self.assertEqual(response['method'], 'POST')
@@ -84,15 +93,32 @@ class TestAdmin(unittest.TestCase):
             util.params_to_dict(response['body']),
             {'username':['bar'], 'account_id':[self.client.account_id]})
 
-    # POST with no params
     def test_update_user(self):
-        response = self.client.update_user('DU012345678901234567')
+        response = self.client.update_user(
+            'DU012345678901234567', username='foo', realname='bar',
+            status='active', notes='notes', email='foobar@baz.com',
+            firstname='fName', lastname='lName', alias1='alias1',
+            alias2='alias2', alias3='alias3', alias4='alias4')
         self.assertEqual(response['method'], 'POST')
         self.assertEqual(
             response['uri'], '/admin/v1/users/DU012345678901234567')
         self.assertEqual(
             util.params_to_dict(response['body']),
-            {'account_id':[self.client.account_id]})
+            {
+                'account_id':[self.client.account_id],
+                'realname': ['bar'],
+                'notes': ['notes'],
+                'username': ['foo'],
+                'status': ['active'],
+                'email': ['foobar%40baz.com'],
+                'firstname': ['fName'],
+                'lastname': ['lName'],
+                'account_id': [self.client.account_id],
+                'alias1': ['alias1'],
+                'alias2': ['alias2'],
+                'alias3': ['alias3'],
+                'alias4': ['alias4'],
+            })
 
     def test_get_endpoints(self):
         response = self.client.get_endpoints()


### PR DESCRIPTION
Fixes #45. Update adminapi client to include alias1-4 parameters for add_user and update_user. This allows the caller to specify up to 4 additional username aliases for the user.