### PR TITLE
Rename async parameter, be stricter about expecting a boolean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,3 @@ install:
     - pip install -r requirements-dev.txt
 script:
     - nose2
-matrix:
-  allow_failures:
-    - python: 3.7-dev

--- a/duo_client/auth.py
+++ b/duo_client/auth.py
@@ -112,7 +112,7 @@ class Auth(client.Client):
              username=None,
              user_id=None,
              ipaddr=None,
-             async=False,
+             async_txn=False,
              type=None,
              display_username=None,
              pushinfo=None,
@@ -121,7 +121,7 @@ class Auth(client.Client):
         """
         Perform second-factor authentication for a user.
 
-        If async is True, returns: {
+        If async_txn is True, returns: {
             'txid': <str: transaction ID for use with auth_status>,
         }
 
@@ -131,14 +131,14 @@ class Auth(client.Client):
             'status_msg': <str:human-readable>,
         }
 
-        If Trusted Devices is enabled, async is not True, and status is
+        If Trusted Devices is enabled, async_txn is not True, and status is
         'allow', another item is returned:
 
         * trusted_device_token: <str: device token for use with preauth>
         """
         params = {
             'factor': factor,
-            'async': str(int(bool(async))),
+            'async': str(int(async_txn)),
         }
         if username is not None:
             params['username'] = username

--- a/duo_client/auth_v1.py
+++ b/duo_client/auth_v1.py
@@ -69,17 +69,17 @@ class AuthV1(client.Client):
              phone=PHONE1,
              pushinfo=None,
              ipaddr=None,
-             async=False):
+             async_txn=False):
         """
         Returns True if authentication was a success, else False.
 
-        If 'async' is True, returns txid of the authentication transaction.
+        If 'async_txn' is True, returns txid of the authentication transaction.
         """
         params = {
             'user': username,
             'factor': factor,
         }
-        if async:
+        if async_txn:
             params['async'] = '1'
         if pushinfo is not None:
             params['pushinfo'] = pushinfo
@@ -100,7 +100,7 @@ class AuthV1(client.Client):
         response = self.json_api_call('POST', '/rest/v1/auth', params)
         if self.auth_details:
             return response
-        if async:
+        if async_txn:
             return response['txid']
         return response['result'] == 'allow'
 

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import six
 
-__version__ = '3.3.0'
+__version__ = '4.0.0'
 
 import base64
 import collections


### PR DESCRIPTION
Rename the `async` parameter to avoid colliding with the new Python 3.7 keyword.  Thus, expect Python 3.7 to pass on TravisCI.

Be slightly stricter about expecting a Boolean for the new parameter.

Major version bump since this is technically a backwards-incompatible change.