### PR TITLE
Make limit optional for admin.get_tokens

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -1185,7 +1185,7 @@ class Admin(client.Client):
             params)
         return response
 
-    def get_tokens(self, limit=100, offset=0):
+    def get_tokens(self, limit=None, offset=0):
         """
         Returns list of tokens.
 
@@ -1194,10 +1194,11 @@ class Admin(client.Client):
 
         Returns list of token objects.
         """
-        params = {
-            'limit': str(limit),
-            'offset': str(offset),
-        }
+        params = {}
+        if limit is not None:
+            params['limit'] = str(limit)
+            params['offset'] = str(offset)
+
         response = self.json_api_call(
             'GET', '/admin/v1/tokens',
             params

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -332,8 +332,6 @@ class TestAdmin(unittest.TestCase):
             util.params_to_dict(args),
             {
                 'account_id': [self.client.account_id],
-                'limit': ['100'],
-                'offset': ['0'],
             })
 
     def test_get_tokens_with_params(self):


### PR DESCRIPTION
Ensure backwards compatibility by setting default value for limit to None