### PR TITLE
Add admin get_group_users_iterator and call from get_group_users

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2016,8 +2016,8 @@ class Admin(client.Client):
                 'GET',
                 '/admin/v2/groups/' + group_id + '/users',
                 {
-                    'limit': str(limit),
-                    'offset': str(offset),
+                    'limit': limit,
+                    'offset': offset,
                 })
         return list(self.get_group_users_iterator(group_id))
 

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2001,7 +2001,7 @@ class Admin(client.Client):
 
         return self.json_api_call('GET', url + group_id, {})
 
-    def get_group_users(self, group_id, limit=100, offset=0):
+    def get_group_users(self, group_id, limit=None, offset=0):
         """
         Get a paginated list of users associated with the specified
         group.
@@ -2010,13 +2010,28 @@ class Admin(client.Client):
         limit - The maximum number of records to return. Maximum is 500. (Optional)
         offset - The offset of the first record to return. (Optional)
         """
-        return self.json_api_call(
+        (limit, offset) = self.normalize_paging_args(limit, offset)
+        if limit:
+            return self.json_api_call(
+                'GET',
+                '/admin/v2/groups/' + group_id + '/users',
+                {
+                    'limit': str(limit),
+                    'offset': str(offset),
+                })
+        return list(self.get_group_users_iterator(group_id))
+
+    def get_group_users_iterator(self, group_id):
+        """
+        Returns an iterator of users associated with the specified group.
+
+        group_id - The id of the group (Required)
+        """
+        return self.json_paging_api_call(
             'GET',
             '/admin/v2/groups/' + group_id + '/users',
-            {
-                'limit': str(limit),
-                'offset': str(offset),
-            })
+            {}
+        )
 
     def create_group(self, name,
                     desc=None,

--- a/tests/admin/test_groups.py
+++ b/tests/admin/test_groups.py
@@ -119,7 +119,7 @@ class TestGroups(TestAdmin):
     def test_get_group_users(self):
         """ Test for getting list of users associated with a group
         """
-        response = self.client.get_group_users('ABC123')
+        response = self.client_list.get_group_users('ABC123')[0]
         uri, args = response['uri'].split('?')
 
         self.assertEqual(response['method'], 'GET')
@@ -131,6 +131,69 @@ class TestGroups(TestAdmin):
                 'limit': ['100'],
                 'offset': ['0'],
             })
+
+    def test_get_group_users_with_offset(self):
+        """Test to get users by group id with pagination params
+        """
+        response = self.client_list.get_group_users('ABC123', offset=30)[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/groups/ABC123/users')
+        self.assertEqual(util.params_to_dict(args),
+                         {
+                            'account_id':[self.client.account_id],
+                            'limit': ['100'],
+                            'offset': ['0'],
+                         })
+
+    def test_get_group_users_with_limit(self):
+        """Test to get users by group id with pagination params
+        """
+        response = self.client_list.get_group_users('ABC123', limit=30)[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/groups/ABC123/users')
+        self.assertEqual(util.params_to_dict(args),
+                         {
+                            'account_id':[self.client.account_id],
+                            'limit': ['30'],
+                            'offset': ['0'],
+                         })
+
+    def test_get_group_users_with_limit_and_offset(self):
+        """Test to get users by group id with pagination params
+        """
+        response = self.client_list.get_group_users(
+            'ABC123', limit=30, offset=60)[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/groups/ABC123/users')
+        self.assertEqual(util.params_to_dict(args),
+                         {
+                            'account_id':[self.client.account_id],
+                            'limit': ['30'],
+                            'offset': ['60'],
+                         })
+
+    def test_get_group_users_iterator(self):
+        """Test to get user iterator by group id
+        """
+        iterator = self.client_list.get_group_users_iterator(
+            'ABC123')
+        response = next(iterator)
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/groups/ABC123/users')
+        self.assertEqual(util.params_to_dict(args),
+                         {
+                            'account_id':[self.client.account_id],
+                            'limit': ['100'],
+                            'offset': ['0'],
+                         })
 
     def test_delete_group(self):
         """ Test for deleting a group


### PR DESCRIPTION
We missed adding an iterator for `get_group_users`, so add it here. As a side effect, `get_group_users` will now return the full result set, rather than the first 100. Fixes #85 

```
$ nose2
.........................................................................................................................................
----------------------------------------------------------------------
Ran 137 tests in 0.134s

OK
```