### PR TITLE
Add backoff and retry when a request is rate limited

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 nose2
 flake8
 pytz
+mock

--- a/tests/util.py
+++ b/tests/util.py
@@ -109,3 +109,23 @@ class MockPagingHTTPConnection(MockHTTPConnection):
 
         self.limit = int(params['limit'][0])
         self.offset = int(params['offset'][0])
+
+
+class MockMultipleRequestHTTPConnection(MockHTTPConnection):
+    def __init__(self, statuses):
+        super(MockMultipleRequestHTTPConnection, self).__init__()
+        self.statuses = statuses
+        self.status_iterator = iter(statuses)
+        self.requests = 0
+        self.status = None
+
+    def read(self):
+        response = {'foo': 'bar'}
+        return json.dumps({"stat":"OK", "response":response},
+                              cls=MockObjectJsonEncoder)
+
+    def request(self, method, uri, body, headers):
+        self.requests += 1
+        self.status = next(self.status_iterator)
+        super(MockMultipleRequestHTTPConnection, self).request(
+            method, uri, body, headers)


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.