### PR TITLE
Add Dlint to CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+select = DUO
+exclude = duo_client/https_wrapper.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ install:
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
 script:
+    - flake8
     - nose2

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ $ nose2
 # Linting
 
 ```
-$ flake8 --ignore=E501 duo_client/ tests/
+$ flake8
 ```

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -105,7 +105,7 @@ def canonicalize(method, host, uri, params, date, sig_version):
 
 
 def sign(ikey, skey, method, host, uri, date, sig_version, params,
-         digestmod=hashlib.sha1):
+         digestmod=hashlib.sha1):  # noqa: DUO130, HMAC-SHA1 still secure
     """
     Return basic authorization header line with a Duo Web API signature.
     """
@@ -154,7 +154,7 @@ class Client(object):
                  user_agent=('Duo API Python/' + __version__),
                  timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
                  paging_limit=100,
-                 digestmod=hashlib.sha1,
+                 digestmod=hashlib.sha1,  # noqa: DUO130, HMAC-SHA1 still secure
                  sig_version=2
                  ):
         """
@@ -295,7 +295,7 @@ class Client(object):
             if hasattr(ssl, '_create_unverified_context'):
                 # httplib.HTTPSConnection validates certificates by
                 # default in Python 2.7.9+.
-                kwargs['context'] = ssl._create_unverified_context()
+                kwargs['context'] = ssl._create_unverified_context()  # noqa: DUO122, explicitly disabled for testing scenarios
             conn = six.moves.http_client.HTTPSConnection(host, port, **kwargs)
         else:
             conn = CertValidatingHTTPSConnection(host,
@@ -339,7 +339,7 @@ class Client(object):
             if (response.status != self._RATE_LIMITED_RESP_CODE or
                     wait_secs > self._MAX_BACKOFF_WAIT_SECS):
                 break
-            random_offset = random.uniform(0.0, 1.0)
+            random_offset = random.uniform(0.0, 1.0)  # noqa: DUO102, non-cryptographic random use
             sleep(wait_secs + random_offset)
             wait_secs = wait_secs * self._BACKOFF_FACTOR
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ nose2
 flake8
 pytz
 mock
+dlint

--- a/tests/test_https_wrapper.py
+++ b/tests/test_https_wrapper.py
@@ -8,7 +8,7 @@ class TestSSLContextCreation(unittest.TestCase):
     """ Test that the SSL context used to wrap sockets is configured correctly """
     def test_no_ca_certs(self):
         conn = CertValidatingHTTPSConnection('fake host')
-        self.assertEqual(conn.default_ssl_context.verify_mode, ssl.CERT_NONE)
+        self.assertEqual(conn.default_ssl_context.verify_mode, ssl.CERT_NONE)  # noqa: DUO122, testing insecure context
 
     @mock.patch('ssl.SSLContext.load_verify_locations')
     def test_with_ca_certs(self, mock_load):


### PR DESCRIPTION
Hi, I'm back with round 2...

To explain some of the changes here:

- Via flake8's config setting `select = DUO` we're only running Dlint rules, as opposed to all flake8's rules. This is because there are a couple hundred flake8 violations, and I didn't want to include fixes in this PR.
- We're excluding `duo_client/https_wrapper.py` from analysis because it's a third-party library. Although note it would have the following violations: `./duo_client/https_wrapper.py:72:34: DUO122 insecure "ssl" module attribute use` and `./duo_client/https_wrapper.py:79:35: DUO122 insecure "ssl" module attribute use`.

Let me know if you'd like anything done differently :+1: 