### PR TITLE
Correct pypi package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ python setup.py install
 System:
 
 ```
-$ pip install duo_client
+$ pip install duo-client
 ```
 
 # Using


### PR DESCRIPTION
Though pypi considers dashes and underscores in package names to be the same, in the case of `duo-client` the canonical name of the package is [`duo-client`](https://pypi.org/project/duo-client/) not `duo_client`.
When using a package management tool other than pip, for example an IDE, searching for duo_client won't return anything as the actual pypi package name is duo-client.