### PR TITLE
Pin dependency versions using `pip freeze`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,11 @@
-nose2
-flake8
-pytz
-mock
-dlint
+coverage==5.1
+dlint==0.10.3
+entrypoints==0.3
+flake8==3.7.9
+mccabe==0.6.1
+mock==4.0.2
+nose2==0.9.2
+pycodestyle==2.5.0
+pyflakes==2.1.1
+pytz==2019.3
+six==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-six
-setuptools
+six==1.14.0


### PR DESCRIPTION
Hi there!

This pull request pins the versions of both the standard and development dependencies. I was using Python 3, and created the following files using:

```bash
# Development dependencies
python3 -m venv .env-dev
source .env-dev/bin/activate
pip install -r requirements-dev.txt
pip freeze > requirements-dev.txt

# Standard dependencies
python3 -m venv .env
source .env/bin/activate
pip install -r requirements.txt
pip freeze > requirements.txt
```