### PR TITLE
duo_client says it accepts booleans, but fails on non-string input

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -133,8 +133,14 @@ def normalize_params(params):
     """
     # urllib cannot handle unicode strings properly. quote() excepts,
     # and urlencode() replaces them with '?'.
+    # converts booleans and ints to strings
     def encode(value):
-        if isinstance(value, bool):
+        if isinstance(value, bool) and value:
+            if value:
+                value = 'true'
+            else:
+                value = 'false'
+        elif isinstance(value, int):
             value = str(value)
         if isinstance(value, six.text_type):
             return value.encode("utf-8")

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -134,6 +134,8 @@ def normalize_params(params):
     # urllib cannot handle unicode strings properly. quote() excepts,
     # and urlencode() replaces them with '?'.
     def encode(value):
+        if isinstance(value, bool):
+            value = str(value)
         if isinstance(value, six.text_type):
             return value.encode("utf-8")
         return value

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,10 +48,10 @@ class TestQueryParameters(unittest.TestCase):
             {'realname': ['First Last'], 'username': ['root']},
             'realname=First%20Last&username=root')
 
-    def test_with_boolean_and_string(self):
+    def test_with_boolean_int_and_string(self):
         self.assert_canon_params(
-            {'realname': ['First Last'], 'username': [True]},
-            'realname=First%20Last&username=True')
+            {'words': ['First Last'], 'success': [True], 'digit': [5]},
+            'digit=5&success=true&words=First%20Last')
 
     def test_list_string(self):
         """ A list and a string will both get converted. """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,6 +48,11 @@ class TestQueryParameters(unittest.TestCase):
             {'realname': ['First Last'], 'username': ['root']},
             'realname=First%20Last&username=root')
 
+    def test_with_boolean_and_string(self):
+        self.assert_canon_params(
+            {'realname': ['First Last'], 'username': [True]},
+            'realname=First%20Last&username=True')
+
     def test_list_string(self):
         """ A list and a string will both get converted. """
         self.assert_canon_params(


### PR DESCRIPTION
Mades minor change to normalize_params in client.py so it converts booleans into strings. I believe this a valid solution to it breaking when booleans are inputed since they are used to construct urls. I decide to make them lower case since that is what is used in JSON. While it was not explicitly included in the task, I also convert ints to strings so they are another potential non-string input. Finally I created a new tests for this new functionality. 
