### PR TITLE
duo_client says it accepts booleans, but fails on non-string input

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -133,8 +133,14 @@ def normalize_params(params):
     """
     # urllib cannot handle unicode strings properly. quote() excepts,
     # and urlencode() replaces them with '?'.
+    # converts booleans and ints to strings
     def encode(value):
-        if isinstance(value, bool):
+        if isinstance(value, bool) and value:
+            if value:
+                value = 'true'
+            else:
+                value = 'false'
+        elif isinstance(value, int):
             value = str(value)
         if isinstance(value, six.text_type):
             return value.encode("utf-8")

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -134,6 +134,8 @@ def normalize_params(params):
     # urllib cannot handle unicode strings properly. quote() excepts,
     # and urlencode() replaces them with '?'.
     def encode(value):
+        if isinstance(value, bool):
+            value = str(value)
         if isinstance(value, six.text_type):
             return value.encode("utf-8")
         return value

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,10 +48,10 @@ class TestQueryParameters(unittest.TestCase):
             {'realname': ['First Last'], 'username': ['root']},
             'realname=First%20Last&username=root')
 
-    def test_with_boolean_and_string(self):
+    def test_with_boolean_int_and_string(self):
         self.assert_canon_params(
-            {'realname': ['First Last'], 'username': [True]},
-            'realname=First%20Last&username=True')
+            {'words': ['First Last'], 'success': [True], 'digit': [5]},
+            'digit=5&success=true&words=First%20Last')
 
     def test_list_string(self):
         """ A list and a string will both get converted. """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,6 +48,11 @@ class TestQueryParameters(unittest.TestCase):
             {'realname': ['First Last'], 'username': ['root']},
             'realname=First%20Last&username=root')
 
+    def test_with_boolean_and_string(self):
+        self.assert_canon_params(
+            {'realname': ['First Last'], 'username': [True]},
+            'realname=First%20Last&username=True')
+
     def test_list_string(self):
         """ A list and a string will both get converted. """
         self.assert_canon_params(


### PR DESCRIPTION
Converts booleans and ints to lower case strings since they are used in a url string. Makes booleans lower case since they are lower case in JSON. Also added test to check they both boolean cases as well as ints work properly. 