### PR TITLE
Updated admin activation link endpoint

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2602,7 +2602,7 @@ class Admin(client.Client):
             "admin_role": <str:administrator role assigned to the new admin>
             "code": <str:activation code>
             "email": <str:email for admin/message>
-            "email_sent": <bool:true if email was sent, false otherwise>
+            "email_sent": <string:true if email was sent, false otherwise>
             "expires": <int:timestamp of expiration>
             "link": <str:activation link>
             "message": <str:message in email body>
@@ -2619,7 +2619,7 @@ class Admin(client.Client):
         if email is not None:
             params['email'] = email
         if send_email is not None:
-            params['send_email'] = '1' if send_email else '0'
+            params['send_email'] = str(send_email)
         if valid_days is not None:
             params['valid_days'] = str(valid_days)
         if admin_role is not None:

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2586,22 +2586,31 @@ class Admin(client.Client):
 
     def activate_admin(self, email,
                        send_email=False,
-                       valid_days=None):
+                       valid_days=None,
+                       admin_role=None):
         """
-        Generates an activate code for an administrator and optionally
+        Generates an activation code for an administrator and optionally
         emails the administrator.
 
         email - <str:email address of administrator>
         valid_days - <int:number of days> (optional)
-        send_email - <bool: True if email should be sent> (optional)
+        send_email - <bool:True if email should be sent> (optional)
+        admin_role - <str: Role assigned to new admin> (optional)
 
         Returns {
-            "email": <str:email for admin/message>,
-            "valid_days": <int:valid days>
-            "link": <str:activation link>
-            "message": <str:message, whether sent or not>
-            "email_sent": <bool:true if email was sent, false otherwise>
+            "admin_activation_id": <str:ID of the administrator activation link>
+            "admin_role": <str:administrator role assigned to the new admin>
             "code": <str:activation code>
+            "email": <str:email for admin/message>
+            "email_sent": <bool:true if email was sent, false otherwise>
+            "expires": <int:timestamp of expiration>
+            "link": <str:activation link>
+            "message": <str:message in email body>
+            "subject": <str:email subject line>
+            "valid_days": <int:valid days>
+
+            "message": <str:message, whether sent or not>
+
         }
 
         See the adminapi docs for updated return values.
@@ -2615,8 +2624,10 @@ class Admin(client.Client):
             params['send_email'] = '1' if send_email else '0'
         if valid_days is not None:
             params['valid_days'] = str(valid_days)
+        if admin_role is not None:
+            params['admin_role'] = str(admin_role)
         response = self.json_api_call('POST',
-                                      '/admin/v1/admins/activate',
+                                      '/admin/v1/admins/activations',
                                       params)
         return response
 

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2609,8 +2609,6 @@ class Admin(client.Client):
             "subject": <str:email subject line>
             "valid_days": <int:valid days>
 
-            "message": <str:message, whether sent or not>
-
         }
 
         See the adminapi docs for updated return values.

--- a/tests/admin/test_admins.py
+++ b/tests/admin/test_admins.py
@@ -74,3 +74,27 @@ class TestAdmins(TestAdmin):
                 'limit': ['100'],
                 'offset': ['0'],
             })
+
+    def test_admin_activation(self):
+            # all params given
+            response = self.client.activate_admin(
+                email='foobar@baz.com', send_email=True, valid_days=2, admin_role='Admin')
+            self.assertEqual(response['method'], 'POST')
+            self.assertEqual(response['uri'], '/admin/v1/admins/activations')
+            response_body = util.params_to_dict(response['body'])
+
+            self.assertEqual(response_body['admin_role'], 'Admin')
+            self.assertEqual(response_body['email'], 'foobar@baz.com')
+            self.assertEqual(response_body['email_sent'], True)
+            self.assertEqual(response_body['valid_days'], 2)
+
+            # only required params given
+            response = self.client.activate_admin(email='foobartwo@baz.com')
+            self.assertEqual(response['method'], 'POST')
+            self.assertEqual(response['uri'], '/admin/v1/admins/activations')
+            response_body = util.params_to_dict(response['body'])
+
+            self.assertEqual(response_body['admin_role'], 'Owner')
+            self.assertEqual(response_body['email'], 'foobartwo@baz.com')
+            self.assertEqual(response_body['email_sent'], False)
+            self.assertEqual(response_body['valid_days'], 7)

--- a/tests/admin/test_admins.py
+++ b/tests/admin/test_admins.py
@@ -1,6 +1,6 @@
 from .. import util
 import duo_client.admin
-import urllib
+import urllib.parse
 from .base import TestAdmin
 
 
@@ -85,7 +85,7 @@ class TestAdmins(TestAdmin):
             response_body = util.params_to_dict(response['body'])
 
             self.assertEqual(response_body['admin_role'], ['Admin'])
-            self.assertEqual(response_body['email'], [urllib.quote('foobar@baz.com')])
+            self.assertEqual(response_body['email'], [urllib.parse.quote('foobar@baz.com')])
             self.assertEqual(response_body['send_email'], ['1'])
             self.assertEqual(response_body['valid_days'], ['2'])
 
@@ -95,4 +95,4 @@ class TestAdmins(TestAdmin):
             self.assertEqual(response['uri'], '/admin/v1/admins/activations')
             response_body = util.params_to_dict(response['body'])
 
-            self.assertEqual(response_body['email'], [urllib.quote('foobartwo@baz.com')])
+            self.assertEqual(response_body['email'], [urllib.parse.quote('foobartwo@baz.com')])

--- a/tests/admin/test_admins.py
+++ b/tests/admin/test_admins.py
@@ -1,6 +1,5 @@
 from .. import util
 import duo_client.admin
-import urllib.parse
 from .base import TestAdmin
 
 
@@ -75,24 +74,3 @@ class TestAdmins(TestAdmin):
                 'limit': ['100'],
                 'offset': ['0'],
             })
-
-    def test_admin_activation(self):
-            # all params given
-            response = self.client.activate_admin(
-                email='foobar@baz.com', send_email=1, valid_days=2, admin_role='Admin')
-            self.assertEqual(response['method'], 'POST')
-            self.assertEqual(response['uri'], '/admin/v1/admins/activations')
-            response_body = util.params_to_dict(response['body'])
-
-            self.assertEqual(response_body['admin_role'], ['Admin'])
-            self.assertEqual(response_body['email'], [urllib.parse.quote('foobar@baz.com')])
-            self.assertEqual(response_body['send_email'], ['1'])
-            self.assertEqual(response_body['valid_days'], ['2'])
-
-            # only required params given
-            response = self.client.activate_admin(email='foobartwo@baz.com')
-            self.assertEqual(response['method'], 'POST')
-            self.assertEqual(response['uri'], '/admin/v1/admins/activations')
-            response_body = util.params_to_dict(response['body'])
-
-            self.assertEqual(response_body['email'], [urllib.parse.quote('foobartwo@baz.com')])

--- a/tests/admin/test_admins.py
+++ b/tests/admin/test_admins.py
@@ -1,5 +1,6 @@
 from .. import util
 import duo_client.admin
+import urllib
 from .base import TestAdmin
 
 
@@ -78,15 +79,15 @@ class TestAdmins(TestAdmin):
     def test_admin_activation(self):
             # all params given
             response = self.client.activate_admin(
-                email='foobar@baz.com', send_email=True, valid_days=2, admin_role='Admin')
+                email='foobar@baz.com', send_email=1, valid_days=2, admin_role='Admin')
             self.assertEqual(response['method'], 'POST')
             self.assertEqual(response['uri'], '/admin/v1/admins/activations')
             response_body = util.params_to_dict(response['body'])
 
-            self.assertEqual(response_body['admin_role'], 'Admin')
-            self.assertEqual(response_body['email'], 'foobar@baz.com')
-            self.assertEqual(response_body['email_sent'], True)
-            self.assertEqual(response_body['valid_days'], 2)
+            self.assertEqual(response_body['admin_role'], ['Admin'])
+            self.assertEqual(response_body['email'], [urllib.quote('foobar@baz.com')])
+            self.assertEqual(response_body['send_email'], ['1'])
+            self.assertEqual(response_body['valid_days'], ['2'])
 
             # only required params given
             response = self.client.activate_admin(email='foobartwo@baz.com')
@@ -94,7 +95,4 @@ class TestAdmins(TestAdmin):
             self.assertEqual(response['uri'], '/admin/v1/admins/activations')
             response_body = util.params_to_dict(response['body'])
 
-            self.assertEqual(response_body['admin_role'], 'Owner')
-            self.assertEqual(response_body['email'], 'foobartwo@baz.com')
-            self.assertEqual(response_body['email_sent'], False)
-            self.assertEqual(response_body['valid_days'], 7)
+            self.assertEqual(response_body['email'], [urllib.quote('foobartwo@baz.com')])


### PR DESCRIPTION
The new admin activation link creation endpoint is `POST /admin/v1/admins/activations`, instead of `POST /admin/v1/admins/activate`. I updated this end point with the relevant information about parameters and response information. 

Source from the docs [here](https://duo.com/docs/adminapi#create-administrator-activation-link).