### PR TITLE
Adding new endpoint to fetch trust monitor events from the admin api

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2876,3 +2876,96 @@ class Admin(client.Client):
             '/admin/v1/users/directorysync/{directory_key}/syncuser').format(
                 directory_key=directory_key)
         return self.json_api_call('POST', path, params)
+
+    def get_trust_monitor_events_iterator(
+        self,
+        mintime,
+        maxtime,
+        event_type=None,
+    ):
+        """
+        Returns a generator which yields trust monitor events.
+
+        Params:
+            mintime (int) - Return events that have a surfaced timestamp greater
+                            than or equal to mintime. Timestamp is represented as
+                            a unix timestamp in milliseconds.
+            maxtime (int) - Return events that have a surfaced timestamp less
+                            than or equal to maxtime. Timestamp is represented as
+                            a unix timestamp in milliseconds.
+            event_type (str, optional) - Limit the events returned by a supplied
+                                         event type represented as a string. If
+                                         not supplied, the caller will recieve all
+                                         event types. Check the Duo Admin API
+                                         documentation for expected values for
+                                         this parameter.
+
+        Returns: Generator which yields trust monitor events.
+        """
+
+        params = {
+            "mintime": "{}".format(mintime),
+            "maxtime": "{}".format(maxtime),
+        }
+
+        if event_type is not None:
+            params["type"] = event_type
+
+        return self.json_cursor_api_call(
+            "GET",
+            "/admin/v1/trust_monitor/events",
+            params,
+            lambda resp: resp["events"],
+        )
+
+    def get_trust_monitor_events_by_offset(
+        self,
+        mintime,
+        maxtime,
+        limit=None,
+        offset=None,
+        event_type=None,
+    ):
+        """
+        Fetch Duo Trust Monitor Events from the Admin API.
+
+        Params:
+            mintime (int) - Return events that have a surfaced timestamp greater
+                            than or equal to mintime. Timestamp is represented as
+                            a unix timestamp in milliseconds.
+            maxtime (int) - Return events that have a surfaced timestamp less
+                            than or equal to maxtime. Timestamp is represented as
+                            a unix timestamp in milliseconds.
+            limit (int, optional) - Limit the number of events returned.
+            offset (str, optional) - Provide an offset from a previous request's
+                                     response metadata["next_offset"].
+            event_type (str, optional) - Limit the events returned by a supplied
+                                         event type represented as a string. If
+                                         not supplied, the caller will recieve all
+                                         event types. Check the Duo Admin API
+                                         documentation for expected values for
+                                         this parameter.
+
+        Returns: response containing a list of Duo Trust Monitor Events.
+
+        """
+
+        params = {
+            "mintime": "{}".format(mintime),
+            "maxtime": "{}".format(maxtime),
+        }
+
+        if limit is not None:
+            params["limit"] = "{}".format(limit)
+
+        if offset is not None:
+            params["offset"] = "{}".format(offset)
+
+        if event_type is not None:
+            params["type"] = event_type
+
+        return self.json_api_call(
+            "GET",
+            "/admin/v1/trust_monitor/events",
+            params,
+        )

--- a/tests/admin/base.py
+++ b/tests/admin/base.py
@@ -32,6 +32,17 @@ class TestAdmin(unittest.TestCase):
         self.client_authlog._connect = \
             lambda: util.MockHTTPConnection(data_response_from_get_authlog=True)
 
+        # client to simulate basic structure of a call to fetch Duo Trust
+        # Monitor events.
+        self.client_dtm = duo_client.admin.Admin(
+            'test_ikey',
+            'test_akey',
+            'example.com',
+        )
+        self.client_dtm.account_id = 'DA012345678901234567'
+        self.client_dtm._connect = \
+            lambda: util.MockHTTPConnection(data_response_from_get_dtm_events=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/admin/test_trust_monitor_events.py
+++ b/tests/admin/test_trust_monitor_events.py
@@ -1,0 +1,50 @@
+from .. import util
+import duo_client.admin
+from .base import TestAdmin
+
+
+MINTIME = 1603399970000
+MAXTIME = 1603399973797
+LIMIT = 10
+NEXT_OFFSET = "99999"
+EVENT_TYPE = "auth"
+
+
+class TestTrustMonitorEvents(TestAdmin):
+
+    def test_get_trust_monitor_events_iterator(self):
+        """
+        Test to ensure that the correct parameters are supplied when calling
+        next on the generator.
+        """
+
+        generator = self.client_dtm.get_trust_monitor_events_iterator(
+            MINTIME,
+            MAXTIME,
+            event_type=EVENT_TYPE,
+        )
+        events = [e for e in generator]
+        self.assertEqual(events, [{"foo": "bar"},{"bar": "foo"}])
+
+    def test_get_trust_monitor_events_by_offset(self):
+        """
+        Test to ensure that the correct parameters are supplied.
+        """
+
+        res = self.client_list.get_trust_monitor_events_by_offset(
+            MINTIME,
+            MAXTIME,
+            limit=LIMIT,
+            offset=NEXT_OFFSET,
+            event_type=EVENT_TYPE,
+        )[0]
+        uri, qry_str = res["uri"].split("?")
+        args = util.params_to_dict(qry_str)
+
+        self.assertEqual(res["method"], "GET")
+        self.assertEqual(uri, "/admin/v1/trust_monitor/events")
+        self.assertEqual(args["mintime"], ["1603399970000"])
+        self.assertEqual(args["maxtime"], ["1603399973797"])
+        self.assertEqual(args["offset"], ["99999"])
+        self.assertEqual(args["limit"], ["10"])
+        self.assertEqual(args["type"], ["auth"])

--- a/tests/util.py
+++ b/tests/util.py
@@ -24,11 +24,17 @@ class MockHTTPConnection(object):
     """
     status = 200            # success!
 
-    def __init__(self, data_response_should_be_list=False, data_response_from_get_authlog=False):
+    def __init__(
+        self,
+        data_response_should_be_list=False,
+        data_response_from_get_authlog=False,
+        data_response_from_get_dtm_events=False,
+    ):
         # if a response object should be a list rather than
         # a dict, then set this flag to true
         self.data_response_should_be_list = data_response_should_be_list
         self.data_response_from_get_authlog = data_response_from_get_authlog
+        self.data_response_from_get_dtm_events = data_response_from_get_dtm_events
 
     def dummy(self):
         return self
@@ -43,6 +49,9 @@ class MockHTTPConnection(object):
 
         if self.data_response_from_get_authlog:
             response['authlogs'] = []
+
+        if self.data_response_from_get_dtm_events:
+            response['events'] = [{"foo": "bar"}, {"bar": "foo"}]
 
         return json.dumps({"stat":"OK", "response":response},
                               cls=MockObjectJsonEncoder)


### PR DESCRIPTION
This PR adds a client call that allows users to pull Duo Trust Monitor events from the AdminAPI with a fairly basic set of parameters.  We are planning on adding actual documentation to this Duo Admin API endpoint before it goes GA.  Added a unittest to make sure that the parameters were correctly supplied.