### PR TITLE
Adding python3.9 to travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - '3.6'
     - '3.7'
     - '3.8'
+    - '3.9'
 install:
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt

--- a/tests/test_https_wrapper.py
+++ b/tests/test_https_wrapper.py
@@ -7,23 +7,23 @@ import ssl
 class TestSSLContextCreation(unittest.TestCase):
     """ Test that the SSL context used to wrap sockets is configured correctly """
     def test_no_ca_certs(self):
-        conn = CertValidatingHTTPSConnection('fake host')
+        conn = CertValidatingHTTPSConnection('api-fakehost.duosecurity.com')
         self.assertEqual(conn.default_ssl_context.verify_mode, ssl.CERT_NONE)  # noqa: DUO122, testing insecure context
 
     @mock.patch('ssl.SSLContext.load_verify_locations')
     def test_with_ca_certs(self, mock_load):
         mock_load.return_value = None
-        conn = CertValidatingHTTPSConnection('fake host', ca_certs='cafilepath')
+        conn = CertValidatingHTTPSConnection('api-fakehost.duosecurity.com', ca_certs='cafilepath')
         self.assertEqual(conn.default_ssl_context.verify_mode, ssl.CERT_REQUIRED)
         mock_load.assert_called_with(cafile='cafilepath')
 
     @mock.patch('ssl.SSLContext.load_cert_chain')
     def test_with_certfile(self, mock_load):
         mock_load.return_value = None
-        CertValidatingHTTPSConnection('fake host', cert_file='certfilepath')
+        CertValidatingHTTPSConnection('api-fakehost.duosecurity.com', cert_file='certfilepath')
         mock_load.assert_called_with('certfilepath', None)
 
     def test_ssl2_ssl3_off(self):
-        conn = CertValidatingHTTPSConnection('fake host')
+        conn = CertValidatingHTTPSConnection('api-fakehost.duosecurity.com')
         self.assertEqual(conn.default_ssl_context.options & ssl.OP_NO_SSLv2, ssl.OP_NO_SSLv2)
         self.assertEqual(conn.default_ssl_context.options & ssl.OP_NO_SSLv3, ssl.OP_NO_SSLv3)


### PR DESCRIPTION
Since python3.9 was released on Oct 5th 2020, it might be good to start running the test suite with that new version now.