### PR TITLE
Function to fetch a single endpoint object by epkey

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -1058,6 +1058,21 @@ class Admin(client.Client):
         params = {}
         return self.json_api_call('DELETE', path, params)
 
+    def get_endpoint(self, epkey):
+        """
+        Get a single endpoint from the AdminAPI by a supplied epkey.
+
+        Params:
+            epkey (str) - The supplied endpoint key to fetch.
+
+        Returns: The endpoint object represented as a dict.
+        Raises:
+            RuntimeError: if the request returns a non-200 status response.
+        """
+        escaped_epkey = six.moves.urllib.parse.quote_plus(str(epkey))
+        path = '/admin/v1/endpoints/' + escaped_epkey
+        return self.json_api_call('GET', path, {})
+
     def get_endpoints_iterator(self):
         """
         Returns iterator of endpoints objects.

--- a/tests/admin/test_endpoints.py
+++ b/tests/admin/test_endpoints.py
@@ -80,6 +80,19 @@ class TestEndpoints(TestAdmin):
                 'offset': ['20'],
             })
 
+    def test_get_endpoint(self):
+        """ Test getting a single endpoint.
+        """
+        epkey = 'EP18JX1A10AB102M2T2X'
+        response = self.client_list.get_endpoint(epkey)[0]
+        (uri, args) = response['uri'].split('?')
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/endpoints/' + epkey)
+        self.assertEqual(
+            util.params_to_dict(args),
+            {
+                'account_id': [self.client.account_id],
+            })
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This was requested via [issue 136](https://github.com/duosecurity/duo_client_python/issues/136).  It's a small function that will let a user of the library fetch a single endpoint by a supplied epkey parameter.  Added a unittest to cover this new function and manually tested it on an actual Duo environment successfully.

I did notice that the the [documentation](https://duo.com/docs/adminapi#retrieve-endpoint-by-id) for this endpoint might be incorrect or I might be missing something else. Anyways, when I tested it locally the response from the api is a single endpoint dictionary object, but the documentation page says it's a list of a single endpoint dictionary object.

Please feel free to lmk if I should be changing anything else, thank you!

Fixes #136 