### PR TITLE
Adding python3.9 to github ci workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.9 was originally [released back in October 2020](https://docs.python.org/3/whatsnew/3.9.html).  Adding it to the github ci workflow so that CI is running all current versions.  Automated tests seemed to run as expected after observing the changes on my forked repo with 3.9 added.  This would be helpful in the event something specific in 3.9 suddenly breaks some of our tests.