### PR TITLE
Fixes #143: Remove extraneous `Host` header

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -247,7 +247,6 @@ class Client(object):
         headers = {
             'Authorization': auth,
             'Date': now,
-            'Host': self.host,
         }
 
         if self.user_agent:


### PR DESCRIPTION
Python's HTTPConnection already sets a `Host` header when connecting.
Don't set another as this is considered invalid by some HTTP servers.