### PR TITLE
Adding python3.10 to github automated tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
[Python 3.10 was released on October 4th, 2021](https://www.python.org/downloads/release/python-3100/) 🥳 🐍 🎈 so it might be beneficial to make sure that these automated tests w/ github actions are using that specific version moving forward.