### PR TITLE
Fixing urlparse import w/ six.moves.urllib.parse import

### DIFF
--- a/examples/splunk/splunk.py
+++ b/examples/splunk/splunk.py
@@ -1,16 +1,14 @@
 #!/usr/bin/python
 from __future__ import absolute_import
 from __future__ import print_function
-import six.moves.configparser
-import optparse
+
 import os
 import sys
 import time
 
 import duo_client
-
-# For proxy support
-from urlparse import urlparse
+from six.moves.configparser import ConfigParser
+from six.moves.urllib.parse import urlparse
 
 
 class BaseLog(object):
@@ -192,7 +190,7 @@ def admin_api_from_config(config_path):
     Return a duo_client.Admin object created using the parameters
     stored in a config file.
     """
-    config = six.moves.configparser.ConfigParser()
+    config = ConfigParser()
     config.read(config_path)
     config_d = dict(config.items('duo'))
     ca_certs = config_d.get("ca_certs", None)


### PR DESCRIPTION
Fixes #110 by updating the urlparse import to use the appropriate six.moves import so that it's both python2 and python3 compatible.  Tested this manually by pulling some data from a test account with the fixed import statements to make sure the original import error was not getting raised.

```
(.env) ➜  splunk git:(master) ✗ python splunk.py
Traceback (most recent call last):
  File "/Users/kyle/Documents/code/duo_client_python/examples/splunk/splunk.py", line 13, in <module>
    from urlparse import urlparse
ModuleNotFoundError: No module named 'urlparse'
```

I also removed the optparse import since it wasn't being used.