### PR TITLE
Update admin.py

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2550,7 +2550,8 @@ class Admin(client.Client):
                      name=None,
                      phone=None,
                      password=None,
-                     password_change_required=None,
+                     password_change_required=None, 
+                     status=None, 
                      ):
         """
         Update one or more attributes of an administrator.
@@ -2560,6 +2561,7 @@ class Admin(client.Client):
         phone - <str:phone number> (optional)
         password - Deprecated; ignored if specified.
         password_change_required - <bool|None:Whether admin is required to change their password at next login> (optional)
+        status - the status of the adminstrator
 
         Returns the updated administrator.  See the adminapi docs.
 
@@ -2574,6 +2576,8 @@ class Admin(client.Client):
             params['phone'] = phone
         if password_change_required is not None:
             params['password_change_required'] = password_change_required
+        if status is not None:
+            params['status'] = status
         response = self.json_api_call('POST', path, params)
         return response
 

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2561,7 +2561,7 @@ class Admin(client.Client):
         phone - <str:phone number> (optional)
         password - Deprecated; ignored if specified.
         password_change_required - <bool|None:Whether admin is required to change their password at next login> (optional)
-        status - the status of the adminstrator
+        status - the status of the adminstrator (optional) - NOTE: Valid values are "Active" and "Disabled" - "Disabled" NOT valid for administrators with role - Owner
 
         Returns the updated administrator.  See the adminapi docs.
 


### PR DESCRIPTION
Add status to update-admin to allow the ability to set the status of an administrator.  Specifically to disable an administrator account that has never been used, or has not been logged in for an extended time