### PR TITLE
Use Certifi to determine CA file location

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -20,6 +20,7 @@ from time import sleep
 import socket
 import ssl
 import sys
+import certifi
 
 try:
     # For the optional demonstration CLI program.
@@ -37,7 +38,7 @@ except ImportError as e:
 
 from .https_wrapper import CertValidatingHTTPSConnection
 
-DEFAULT_CA_CERTS = os.path.join(os.path.dirname(__file__), 'ca_certs.pem')
+DEFAULT_CA_CERTS = certifi.where()
 
 
 def canon_params(params):


### PR DESCRIPTION
Use `certifi.where()` to determine system provided certs rather than embedded CA file. This allows users with TLS interception firewalls to use the API client as-is.