### PR TITLE
Force use of latest pytz version to fix CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 nose2
 flake8
-pytz
+pytz>=2022.1
 mock
 dlint


### PR DESCRIPTION
CI is failing when trying to build an old version of pytz, so just force it to use a current version