### PR TITLE
T159896: Updating SHA1 to SHA2

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -97,7 +97,7 @@ def canonicalize(method, host, uri, params, date, sig_version, body=None):
 
 
 def sign(ikey, skey, method, host, uri, date, sig_version, params, body=None,
-         digestmod=hashlib.sha1):  # noqa: DUO130, HMAC-SHA1 still secure
+         digestmod=hashlib.sha512):
     """
     Return basic authorization header line with a Duo Web API signature.
     """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -228,6 +228,7 @@ class TestSign(unittest.TestCase):
             sig_version=2,
             ikey=ikey,
             skey='gtdfxv9YgVBYcF6dl2Eq17KUQJN2PLM2ODVTkvoT',
+            digestmod=hashlib.sha1,
             **test
         )
         expected = 'f01811cbbf9561623ab45b893096267fd46a5178'


### PR DESCRIPTION
Updated client to use SHA2 signing for duo api calls.
Modified one sha test to pass successfully.