### PR TITLE
Replace deprecated constant PROTOCOL_SSLv23 with PROTOCOL_TLS

### DIFF
--- a/duo_client/https_wrapper.py
+++ b/duo_client/https_wrapper.py
@@ -69,7 +69,7 @@ class CertValidatingHTTPSConnection(six.moves.http_client.HTTPConnection):
               can't be parsed as a valid HTTP/1.0 or 1.1 status line.
         """
         six.moves.http_client.HTTPConnection.__init__(self, host, port, strict, **kwargs)
-        context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         if cert_file:
             context.load_cert_chain(cert_file, key_file)
         if ca_certs:


### PR DESCRIPTION
Per https://docs.python.org/3/library/ssl.html:
```
ssl.PROTOCOL_TLS
Selects the highest protocol version that both the client and server support. Despite the name, this option can select both “SSL” and “TLS” protocols.

New in version 3.6.
```

```
ssl.PROTOCOL_SSLv23
Alias for [PROTOCOL_TLS](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS).

Deprecated since version 3.6: Use [PROTOCOL_TLS](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS) instead.
```
so there should be no functional change with this update, which we can make now that we don't support 3.5 or earlier.
