### PR TITLE
Change an f-string to .format to restore py2.7 compatibility

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -303,7 +303,7 @@ class Client(object):
                 body = ''
                 params = normalize_params(params)
         else:
-            raise ValueError(f"unsupported sig_version {sig_version}")
+            raise ValueError('unsupported sig_version {}'.format(sig_version))
 
         if self.sig_timezone == 'UTC':
             now = email.utils.formatdate()


### PR DESCRIPTION
42a5a1dc58cd5f5304ceb87d704c4a863011bd5d introduced an fstring which breaks the ability for this module to run on 2.7.  This returns it to a portable format.

And while you can point and laugh that there's still folks using py2, the readme (updated 2w ago) still mentions 2.7, and this isn't a particularly strong break or official declaration that you're dropping 2, so this feel like a bug.