### PR TITLE
Adding policy v2 helpers & example script

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3266,6 +3266,88 @@ class Admin(client.Client):
             params,
         )
 
+    def _quote_policy_id(self, policy_key):
+        return six.moves.urllib.parse.quote_plus("{}".format(policy_key))
+
+    def get_policies_v2_iterator(self):
+        """
+        Obtain an iterator for retrieving all the policies. The order isn't defined.
+        Returns: Iterator of dict elements. Each element contains the policy content.
+        """
+
+        return self.json_paging_api_call(
+            "GET",
+            "/admin/v2/policies",
+            {},
+        )
+
+    def get_policies_v2(self, limit=None, offset=0):
+        """
+        Retrieves a list of policies. The order isn't defined.
+        Args:
+            limit (int, optional): The max number of policies to fetch at once.
+            offset (int, optional): If a limit is passed, the offset to start retrieval.
+                Default 0
+        Raises RuntimeError on error.
+        """
+
+        (limit, offset) = self.normalize_paging_args(limit, offset)
+        if limit:
+            return self.json_api_call(
+                "GET",
+                "/admin/v2/policies",
+                {"limit": limit, "offset": offset},
+            )
+        return list(self.get_policies_v2_iterator())
+
+    def delete_policy_v2(self, policy_key):
+        """
+        Deletes a policy.
+        Params:
+            policy_key (str) - Unique id of the policy
+        Notes:
+            Raises RuntimeError on error.
+        """
+
+        path = "/admin/v2/policies/" + self._quote_policy_id(policy_key)
+        return self.json_api_call("DELETE", path, {})
+
+    def update_policy_v2(self, policy_key, json_request):
+        """
+        Update the content of a single policy
+        Args:
+            policy_key (str) - Unique id of the policy
+            json_request (dict) - policy content to update.
+        Returns (dict) - policy after updates have been made.
+        """
+
+        path = "/admin/v2/policies/" + self._quote_policy_id(policy_key)
+        response = self.json_api_call("PUT", path, json_request)
+        return response
+
+    def create_policy_v2(self, json_request):
+        """
+        Args:
+            json_request (dict) - policy content to create.
+        Returns (dict) - newly created policy
+        """
+
+        path = "/admin/v2/policies"
+        response = self.json_api_call("POST", path, json_request)
+        return response
+
+    def get_policy_v2(self, policy_key):
+        """
+        Args:
+            policy_key: policy_key (str) - Unique id of the policy
+        Returns (dict) - policy content
+        """
+
+        path = "/admin/v2/policies/" + self._quote_policy_id(policy_key)
+        response = self.json_api_call("GET", path, {})
+        return response
+
+
 class AccountAdmin(Admin):
     """AccountAdmin manages a child account using an Accounts API integration."""
 

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+import sys
+import json
+import duo_client
+from six.moves import input
+
+
+argv_iter = iter(sys.argv[1:])
+
+
+def get_next_arg(prompt):
+    try:
+        return next(argv_iter)
+    except StopIteration:
+        return input(prompt)
+
+
+admin_api = duo_client.Admin(
+    ikey=get_next_arg('Admin API integration key ("DI..."): '),
+    skey=get_next_arg("integration secret key: "),
+    host=get_next_arg('API hostname ("api-....duosecurity.com"): '),
+)
+
+
+def create_empty_policy(name, print_response=False):
+    """
+    Create an empty policy with a specified name.
+    """
+
+    json_request = {
+        "name": name,
+    }
+    response = admin_api.create_policy_v2(json_request)
+    if print_response:
+        pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
+        print(pretty)
+    return response.get("policy_key")
+
+
+def create_policy_browsers(name, print_response=False):
+    """
+    Create a policy that blocks internet explorer browsers. Requires
+    Access or Beyond editions.
+    """
+
+    json_request = {
+        "name": name,
+        "sections": {
+            "browsers": {
+                "blocked_browsers_list": [
+                    "ie",
+                ],
+            },
+        },
+    }
+    response = admin_api.create_policy_v2(json_request)
+    if print_response:
+        pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
+        print(pretty)
+    return response.get("policy_key")
+
+
+def update_policy_with_device_health_app(policy_key, print_response=False):
+    """
+    Update a given policy to include Duo Device Health App policy
+    settings. Requires Access or Beyond editions.
+    """
+
+    json_request = {
+        "sections": {
+            "device_health_app": {
+                "enforce_encryption": ["windows"],
+                "enforce_firewall": ["windows"],
+                "prompt_to_install": ["windows"],
+                "requires_DHA": ["windows"],
+                "windows_endpoint_security_list": ["cisco-amp"],
+                "windows_remediation_note": "Please install Windows agent",
+            },
+        },
+    }
+    response = admin_api.update_policy_v2(policy_key, json_request)
+    if print_response:
+        pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
+        print(pretty)
+    return response.get("policy_key")
+
+
+def get_policy(policy_key):
+    """
+    Fetch a given policy.
+    """
+
+    response = admin_api.get_policy_v2(policy_key)
+    pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
+    print(pretty)
+
+
+def iterate_all_policies():
+    """
+    Loop over each policy.
+    """
+
+    print("#####################")
+    print("Iterating over all policies...")
+    print("#####################")
+    iter = sorted(admin_api.get_policies_v2_iterator(), key=lambda x: x.get("name"))
+    for policy in iter:
+        print(
+            "##################### {} {}".format(
+                policy.get("name"), policy.get("policy_key")
+            )
+        )
+        pretty = json.dumps(policy, indent=4, sort_keys=True, default=str)
+        print(pretty)
+
+
+def main():
+    # Create two empty policies
+    policy_key_a = create_empty_policy("Test New Policy - a")
+    policy_key_b = create_empty_policy("Test New Policy - b")
+
+    # Update policy with Duo Device Health App settings.
+    update_policy_with_device_health_app(policy_key_b)
+
+    # Create an empty policy and delete it.
+    policy_key_c = create_empty_policy("Test New Policy - c")
+    admin_api.delete_policy_v2(policy_key_c)
+
+    # Create a policy with browser restriction settings.
+    policy_key_d = create_policy_browsers("Test New Policy - d")
+
+    # Fetch the global and other custom policy.
+    get_policy("global")
+    get_policy(policy_key_b)
+
+    # Loop over each policy.
+    iterate_all_policies()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/admin/test_policies.py
+++ b/tests/admin/test_policies.py
@@ -1,0 +1,75 @@
+from .. import util
+import duo_client.admin
+from .base import TestAdmin
+
+
+class TestPolicies(TestAdmin):
+    def setUp(self):
+        super(TestPolicies, self).setUp()
+        self.client.account_id = None
+        self.client_list.account_id = None
+
+    def test_delete_policy_v2(self):
+        policy_key = "POSTGY2G0HVWJR4JO1XT"
+        response = self.client.delete_policy_v2(policy_key)
+        uri, _ = response["uri"].split("?")
+
+        self.assertEqual(response["method"], "DELETE")
+        self.assertEqual(uri, "/admin/v2/policies/{}".format(policy_key))
+
+    def test_get_policy_v2(self):
+        policy_key = "POSTGY2G0HVWJR4JO1XT"
+        response = self.client.get_policy_v2(policy_key)
+        uri, _ = response["uri"].split("?")
+
+        self.assertEqual(response["method"], "GET")
+        self.assertEqual(uri, "/admin/v2/policies/{}".format(policy_key))
+
+    def test_update_policy_v2(self):
+        policy_key = "POSTGY2G0HVWJR4JO1XT"
+        policy_settings = {
+            "sections": {
+                "browsers": {
+                    "blocked_browsers_list": ["ie"],
+                }
+            }
+        }
+        response = self.client.update_policy_v2(policy_key, policy_settings)
+
+        self.assertEqual(response["method"], "PUT")
+        self.assertEqual(response["uri"], "/admin/v2/policies/{}".format(policy_key))
+
+    def test_create_policy_v2(self):
+        policy_settings = {
+            "name": "my new policy",
+            "sections": {
+                "browsers": {
+                    "blocked_browsers_list": ["ie"],
+                }
+            },
+        }
+        response = self.client.create_policy_v2(policy_settings)
+
+        self.assertEqual(response["method"], "POST")
+        self.assertEqual(response["uri"], "/admin/v2/policies")
+
+    def test_get_policies_v2(self):
+        response = self.client.get_policies_v2(limit=3, offset=0)
+        uri, args = response["uri"].split("?")
+
+        self.assertEqual(response["method"], "GET")
+        self.assertEqual(uri, "/admin/v2/policies")
+        self.assertDictEqual(
+            util.params_to_dict(args), {"limit": ["3"], "offset": ["0"]}
+        )
+
+    def test_get_policies_v2_iterator(self):
+        iterator = self.client_list.get_policies_v2_iterator()
+        response = next(iterator)
+        uri, args = response["uri"].split("?")
+
+        self.assertEqual(response["method"], "GET")
+        self.assertEqual(uri, "/admin/v2/policies")
+        self.assertDictEqual(
+            util.params_to_dict(args), {"limit": ["100"], "offset": ["0"]}
+        )


### PR DESCRIPTION
Adding the following policy api v2 helper methods to `duo_client.Admin`:

1. `duo_client.Admin.get_policies_v2_iterator`.
2. `duo_client.Admin.get_policies_v2`.
3. `duo_client.Admin.delete_policy_v2`.
4. `duo_client.Admin.update_policy_v2`.
5. `duo_client.Admin.create_policy_v2`.
6. `duo_client.Admin.get_policy_v2`.