### PR TITLE
Support SNI in duo client

### DIFF
--- a/duo_client/https_wrapper.py
+++ b/duo_client/https_wrapper.py
@@ -118,7 +118,8 @@ class CertValidatingHTTPSConnection(six.moves.http_client.HTTPConnection):
                                              self.timeout)
         if self._tunnel_host:
             self._tunnel()
-        self.sock = self.default_ssl_context.wrap_socket(self.sock)
+        self.sock = self.default_ssl_context.wrap_socket(self.sock,
+                                                         server_hostname=self.host)
         if self.default_ssl_context.verify_mode == ssl.CERT_REQUIRED:
             cert = self.sock.getpeercert()
             cert_validation_host = self._tunnel_host or self.host

--- a/tests/test_https_wrapper.py
+++ b/tests/test_https_wrapper.py
@@ -27,3 +27,10 @@ class TestSSLContextCreation(unittest.TestCase):
         conn = CertValidatingHTTPSConnection('api-fakehost.duosecurity.com')
         self.assertEqual(conn.default_ssl_context.options & ssl.OP_NO_SSLv2, ssl.OP_NO_SSLv2)
         self.assertEqual(conn.default_ssl_context.options & ssl.OP_NO_SSLv3, ssl.OP_NO_SSLv3)
+
+    @mock.patch('socket.socket.connect')
+    def test_server_hostname(self, mock_connect):
+        hostname = 'api-fakehost.duosecurity.com'
+        conn = CertValidatingHTTPSConnection(hostname)
+        conn.connect()
+        self.assertEqual(conn.sock.server_hostname, hostname)

--- a/tests/test_https_wrapper.py
+++ b/tests/test_https_wrapper.py
@@ -34,3 +34,10 @@ class TestSSLContextCreation(unittest.TestCase):
         conn = CertValidatingHTTPSConnection(hostname)
         conn.connect()
         self.assertEqual(conn.sock.server_hostname, hostname)
+
+    @mock.patch('socket.socket.connect')
+    def test_server_hostname_with_port(self, mock_connect):
+        hostname = 'api-fakehost.duosecurity.com'
+        conn = CertValidatingHTTPSConnection(f'{hostname}:443')
+        conn.connect()
+        self.assertEqual(conn.sock.server_hostname, hostname)


### PR DESCRIPTION
Connecting to a service that uses SSL/TLS with SNI, for example AWS CloudFront, raises an `SSLV3_ALERT_HANDSHAKE_FAILURE` exception. To fix this, pass server hostname to `SSLContext.wrap_socket`. 