### PR TITLE
Add support for alternative metadata placement when paging

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3211,7 +3211,7 @@ class Admin(client.Client):
             "GET",
             "/admin/v1/trust_monitor/events",
             params,
-            lambda resp: resp["events"],
+            lambda resp: resp
         )
 
     def get_trust_monitor_events_by_offset(

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3211,7 +3211,7 @@ class Admin(client.Client):
             "GET",
             "/admin/v1/trust_monitor/events",
             params,
-            lambda resp: resp
+            lambda resp: resp['events']
         )
 
     def get_trust_monitor_events_by_offset(

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3211,7 +3211,7 @@ class Admin(client.Client):
             "GET",
             "/admin/v1/trust_monitor/events",
             params,
-            lambda resp: resp['events']
+            lambda resp: resp["events"],
         )
 
     def get_trust_monitor_events_by_offset(

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -583,7 +583,14 @@ class Client(object):
             data = json.loads(data)
             if data['stat'] != 'OK':
                 raise_error('Received error response: %s' % data)
-            return (data['response'], data.get('metadata', {}))
+            response = data['response']
+            metadata = data.get('metadata', {})
+            if not metadata and not isinstance(response, list):
+                metadata = response.get('metadata', {})
+                if metadata:
+                    response_key = [key for key in response.keys()if key != 'metadata'].pop()
+                    response = response[response_key]
+            return (response, metadata)
         except (ValueError, KeyError, TypeError):
             raise_error('Received bad response: %s' % data)
 

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -546,6 +546,13 @@ class Client(object):
 
         return response
 
+    def get_first_list_value_from_dict(self, object):
+        return [
+            key for key in response.keys()
+            if key != 'metadata' and isinstance(response[key], list)
+        ].pop()
+
+
     def parse_json_response_and_metadata(self, response, data):
         """
         Return the parsed data structure and metadata as a tuple or raise RuntimeError.
@@ -586,9 +593,13 @@ class Client(object):
             response = data['response']
             metadata = data.get('metadata', {})
             if not metadata and not isinstance(response, list):
+            # If the response is an object that we're trying to page over we have to assume
+            # 1. The response has only a `metadata` key and one other key
+            # 2. The "other key" will have a list value
+            # If for some reason there are multiple lists we just take the first one
                 metadata = response.get('metadata', {})
                 if metadata:
-                    response_key = [key for key in response.keys()if key != 'metadata'].pop()
+                    response_key = self.get_first_list_value_from_dict(response)
                     response = response[response_key]
             return (response, metadata)
         except (ValueError, KeyError, TypeError):

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -593,14 +593,8 @@ class Client(object):
             response = data['response']
             metadata = data.get('metadata', {})
             if not metadata and not isinstance(response, list):
-            # If the response is an object that we're trying to page over we have to assume
-            # 1. The response has only a `metadata` key and one other key
-            # 2. The "other key" will have a list value
-            # If for some reason there are multiple lists we just take the first one
                 metadata = response.get('metadata', {})
-                if metadata:
-                    response_key = self.get_first_list_value_from_dict(response)
-                    response = response[response_key]
+
             return (response, metadata)
         except (ValueError, KeyError, TypeError):
             raise_error('Received bad response: %s' % data)

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -546,7 +546,7 @@ class Client(object):
 
         return response
 
-    def get_first_list_value_from_dict(self, object):
+    def get_first_list_value_from_dict(self, response):
         return [
             key for key in response.keys()
             if key != 'metadata' and isinstance(response[key], list)

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -546,13 +546,6 @@ class Client(object):
 
         return response
 
-    def get_first_list_value_from_dict(self, response):
-        return [
-            key for key in response.keys()
-            if key != 'metadata' and isinstance(response[key], list)
-        ].pop()
-
-
     def parse_json_response_and_metadata(self, response, data):
         """
         Return the parsed data structure and metadata as a tuple or raise RuntimeError.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -381,11 +381,13 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(util.params_to_dict(response['body']), self.args_out)
 
 class TestPaging(unittest.TestCase):
+    PagingClass = util.MockPagingHTTPConnection
+
     def setUp(self):
         self.client = util.CountingClient(
             'test_ikey', 'test_akey', 'example.com', paging_limit=100)
         self.objects = [util.MockJsonObject() for i in range(1000)]
-        self.client._connect = lambda: util.MockPagingHTTPConnection(self.objects)
+        self.client._connect = lambda: self.PagingClass(self.objects)
 
     def test_get_objects_paging(self):
         response = self.client.json_paging_api_call(
@@ -413,6 +415,10 @@ class TestPaging(unittest.TestCase):
         expected = [obj.to_json() for obj in self.objects]
         self.assertListEqual(expected, list(response))
         self.assertEqual(1, self.client.counter)
+
+class TestAlternatePaging(TestPaging):
+    PagingClass = util.MockAlternatePagingHTTPConnection
+
 
 class TestRequestsV4(unittest.TestCase):
     # usful args for testing GETs

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -381,7 +381,6 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(util.params_to_dict(response['body']), self.args_out)
 
 class TestPaging(unittest.TestCase):
-
     def setUp(self):
         self.client = util.CountingClient(
             'test_ikey', 'test_akey', 'example.com', paging_limit=100)
@@ -421,7 +420,6 @@ class TestAlternatePaging(unittest.TestCase):
             'test_ikey', 'test_akey', 'example.com', paging_limit=100)
         self.objects = [util.MockJsonObject() for i in range(1000)]
         self.client._connect = lambda: util.MockAlternatePagingHTTPConnection(self.objects)
-        self.client.json_cursor_api_call = self.client.json_cursor_api_call
 
     def test_get_objects_paging(self):
         response = self.client.json_cursor_api_call(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -381,13 +381,12 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(util.params_to_dict(response['body']), self.args_out)
 
 class TestPaging(unittest.TestCase):
-    PagingClass = util.MockPagingHTTPConnection
 
     def setUp(self):
         self.client = util.CountingClient(
             'test_ikey', 'test_akey', 'example.com', paging_limit=100)
         self.objects = [util.MockJsonObject() for i in range(1000)]
-        self.client._connect = lambda: self.PagingClass(self.objects)
+        self.client._connect = lambda: util.MockPagingHTTPConnection(self.objects)
 
     def test_get_objects_paging(self):
         response = self.client.json_paging_api_call(
@@ -416,9 +415,48 @@ class TestPaging(unittest.TestCase):
         self.assertListEqual(expected, list(response))
         self.assertEqual(1, self.client.counter)
 
-class TestAlternatePaging(TestPaging):
-    PagingClass = util.MockAlternatePagingHTTPConnection
+class TestAlternatePaging(unittest.TestCase):
+    def setUp(self):
+        self.client = util.CountingClient(
+            'test_ikey', 'test_akey', 'example.com', paging_limit=100)
+        self.objects = [util.MockJsonObject() for i in range(1000)]
+        self.client._connect = lambda: util.MockAlternatePagingHTTPConnection(self.objects)
+        self.client.json_cursor_api_call = self.client.json_cursor_api_call
 
+    def test_get_objects_paging(self):
+        response = self.client.json_cursor_api_call(
+            'GET', '/admin/v1/objects', {},
+            lambda response: response['data']
+        )
+        self.assertEqual(len(self.objects), len(list(response)))
+        self.assertEqual(10, self.client.counter)
+
+    def test_get_no_objects_paging(self):
+        self.objects = []
+        self.client._connect = lambda: util.MockAlternatePagingHTTPConnection(self.objects)
+        response = self.client.json_cursor_api_call(
+            'GET', '/admin/v1/objects', {},
+            lambda response: response['data']
+        )
+        self.assertEqual(len(self.objects), len(list(response)))
+        self.assertEqual(1, self.client.counter)
+
+    def test_get_objects_paging_limit(self):
+        response = self.client.json_cursor_api_call(
+            'GET', '/admin/v1/objects', {'limit':'250'},
+            lambda response: response['data']
+        )
+        self.assertEqual(len(self.objects), len(list(response)))
+        self.assertEqual(4, self.client.counter)
+
+    def test_get_all_objects(self):
+        response = self.client.json_cursor_api_call(
+            'GET', '/admin/v1/objects', {'limit':'1000'},
+            lambda response: response['data']
+        )
+        expected = [obj.to_json() for obj in self.objects]
+        self.assertListEqual(expected, list(response))
+        self.assertEqual(1, self.client.counter)
 
 class TestRequestsV4(unittest.TestCase):
     # usful args for testing GETs

--- a/tests/util.py
+++ b/tests/util.py
@@ -123,7 +123,10 @@ class MockPagingHTTPConnection(MockHTTPConnection):
         params = six.moves.urllib.parse.parse_qs(parsed.query)
 
         self.limit = int(params['limit'][0])
-        self.offset = int(params['offset'][0])
+
+        # offset is always present with list-based paging but cannot be
+        # present on the initial request with cursor-based paging
+        self.offset = int(params.get('offset', [0])[0])
 
 class MockAlternatePagingHTTPConnection(MockPagingHTTPConnection):
     def read(self):

--- a/tests/util.py
+++ b/tests/util.py
@@ -125,6 +125,24 @@ class MockPagingHTTPConnection(MockHTTPConnection):
         self.limit = int(params['limit'][0])
         self.offset = int(params['offset'][0])
 
+class MockAlternatePagingHTTPConnection(MockPagingHTTPConnection):
+    def read(self):
+        metadata = {}
+        metadata['total_objects'] = len(self.objects)
+        if self.offset + self.limit < len(self.objects):
+            metadata['next_offset'] = self.offset + self.limit
+        if self.offset > 0:
+            metadata['prev_offset'] = max(self.offset-self.limit, 0)
+
+        return json.dumps(
+                {"stat":"OK",
+                 "response": {
+                    "data" : self.objects[self.offset: self.offset+self.limit],
+                    "metadata": metadata
+                  },
+                },
+                cls=MockObjectJsonEncoder)
+
 
 class MockMultipleRequestHTTPConnection(MockHTTPConnection):
     def __init__(self, statuses):


### PR DESCRIPTION
#201 Raised an issue where metadata might exist as either a sibling to `response` on the top-level object or inside of a `response` object. This adds support for either convention to `duo_client_python` along with additional tests for the alternate placement.