### PR TITLE
Add minimun python requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have any questions or need more information, feel free to reach out to su
 * 3.11
 
 ## Requirements
-Duo_client_python supports python 3.7 and higher
+Duo_client_python supports Python 3.7 and higher
 
 ## TLS 1.2 and 1.3 Support
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ If you have any questions or need more information, feel free to reach out to su
 * 3.10
 * 3.11
 
+## Requirements
+Duo_client_python supports python 3.7 and higher
+
 ## TLS 1.2 and 1.3 Support
 
 Duo_client_python uses Python's ssl module and OpenSSL for TLS operations.  Python versions 2.7 (and higher) and 3.5 (and higher) have both TLS 1.2 and TLS 1.3 support.


### PR DESCRIPTION
As title. 3.7 is the lowest python version that ci tested with