### PR TITLE
Fix issue parsing API responses that are just a string

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -585,7 +585,7 @@ class Client(object):
                 raise_error('Received error response: %s' % data)
             response = data['response']
             metadata = data.get('metadata', {})
-            if not metadata and not isinstance(response, list):
+            if not metadata and isinstance(response, dict):
                 metadata = response.get('metadata', {})
 
             return (response, metadata)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -643,6 +643,22 @@ class TestParseJsonResponseAndMetadata(unittest.TestCase):
         except Exception:
             self.fail("parsing raised exception for string response")
 
+    def test_response_is_a_list(self):
+        """
+        Some API requests return just a list in their response. with
+        metadata included at the top level.
+        We want to make sure we handle those correctly
+        """
+        api_res = self.APIResponse(200, "Fake reason")
+        expected_metadata = { "offset": 4 }
+        expected_response = ["multiple", "elements"]
+        response = {
+            "response": expected_response,
+            "metadata": expected_metadata,
+            "stat": "OK"
+        }
+        response, metadata = self.client.parse_json_response_and_metadata(api_res, json.dumps(response))
+        self.assertEqual(metadata, expected_metadata)
 
     def test_response_stat_isnot_OK(self):
         api_res = self.APIResponse(200, 'Fake reason')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -628,6 +628,22 @@ class TestParseJsonResponseAndMetadata(unittest.TestCase):
         self.assertEqual(e.exception.reason, api_res.reason)
         self.assertEqual(e.exception.data, response)
 
+    def test_response_is_a_string(self):
+        """
+        Some API requests return just a string in their response.
+        We want to make sure we handle those correctly
+        """
+        api_res = self.APIResponse(200, 'Fake reason')
+        response = {
+            'response': "just a string",
+            'stat': 'OK'
+        }
+        try:
+            self.client.parse_json_response_and_metadata(api_res, json.dumps(response))
+        except Exception:
+            self.fail("parsing raised exception for string response")
+
+
     def test_response_stat_isnot_OK(self):
         api_res = self.APIResponse(200, 'Fake reason')
 


### PR DESCRIPTION
Fixes #219 by checking for a `dict` before attempting to use `get` to fetch the metadata from inside of a response object.