### PR TITLE
Make sig_version 5 the default signature method for the client

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -213,7 +213,6 @@ VALID_ACTIVITY_REQUEST_PARAMS = ["mintime", "maxtime", "limit", "sort", "next_of
 
 class Admin(client.Client):
     account_id = None
-    sig_version = 5
 
     def api_call(self, method, path, params):
         if self.account_id is not None:
@@ -653,7 +652,7 @@ class Admin(client.Client):
                     'phone': <str:phone number>,
                     'credits': <str:credits>}
             ]
-            
+
         v2 Returns:
             {
                 "items": [

--- a/duo_client/auth_v1.py
+++ b/duo_client/auth_v1.py
@@ -22,6 +22,7 @@ PHONE5 = 'phone5'
 
 
 class AuthV1(client.Client):
+    sig_version = 2
     auth_details = False
 
     def ping(self):

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -212,7 +212,7 @@ def normalize_params(params):
 
 
 class Client(object):
-    sig_version = 2
+    sig_version = 5
 
     def __init__(self, ikey, skey, host,
                  ca_certs=DEFAULT_CA_CERTS,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -336,7 +336,7 @@ class TestRequest(unittest.TestCase):
         (response, dummy) = self.client.api_call('POST', '/foo/bar', {})
         self.assertEqual(response.method, 'POST')
         self.assertEqual(response.uri, '/foo/bar')
-        self.assertEqual(response.body, '')
+        self.assertEqual(json.loads(response.body), {})
 
     def test_api_call_get_params(self):
         (response, dummy) = self.client.api_call(
@@ -351,7 +351,7 @@ class TestRequest(unittest.TestCase):
             'POST', '/foo/bar', self.args_in)
         self.assertEqual(response.method, 'POST')
         self.assertEqual(response.uri, '/foo/bar')
-        self.assertEqual(util.params_to_dict(response.body), self.args_out)
+        self.assertEqual(json.loads(response.body), self.args_out)
 
     def test_json_api_call_get_no_params(self):
         response = self.client.json_api_call('GET', '/foo/bar', {})
@@ -363,7 +363,7 @@ class TestRequest(unittest.TestCase):
         response = self.client.json_api_call('POST', '/foo/bar', {})
         self.assertEqual(response['method'], 'POST')
         self.assertEqual(response['uri'], '/foo/bar')
-        self.assertEqual(response['body'], '')
+        self.assertEqual(json.loads(response['body']), {})
 
     def test_json_api_call_get_params(self):
         response = self.client.json_api_call(
@@ -378,7 +378,7 @@ class TestRequest(unittest.TestCase):
             'POST', '/foo/bar', self.args_in)
         self.assertEqual(response['method'], 'POST')
         self.assertEqual(response['uri'], '/foo/bar')
-        self.assertEqual(util.params_to_dict(response['body']), self.args_out)
+        self.assertEqual(json.loads(response['body']), self.args_out)
 
 class TestPaging(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This makes the default sig_version for the duo client version 5 and only keeps version 2 for AuthV1.