### PR TITLE
Update policy examples with "policy_name" vs "name"

### DIFF
--- a/examples/policies.py
+++ b/examples/policies.py
@@ -28,7 +28,7 @@ def create_empty_policy(name, print_response=False):
     """
 
     json_request = {
-        "name": name,
+        "policy_name": name,
     }
     response = admin_api.create_policy_v2(json_request)
     if print_response:
@@ -44,7 +44,7 @@ def create_policy_browsers(name, print_response=False):
     """
 
     json_request = {
-        "name": name,
+        "policy_name": name,
         "sections": {
             "browsers": {
                 "blocked_browsers_list": [
@@ -103,11 +103,13 @@ def iterate_all_policies():
     print("#####################")
     print("Iterating over all policies...")
     print("#####################")
-    iter = sorted(admin_api.get_policies_v2_iterator(), key=lambda x: x.get("name"))
+    iter = sorted(
+        admin_api.get_policies_v2_iterator(), key=lambda x: x.get("policy_name")
+    )
     for policy in iter:
         print(
             "##################### {} {}".format(
-                policy.get("name"), policy.get("policy_key")
+                policy.get("policy_name"), policy.get("policy_key")
             )
         )
         pretty = json.dumps(policy, indent=4, sort_keys=True, default=str)


### PR DESCRIPTION
## Description
We have made changes to the policy api so that it starts to return and accept a new field for the name: "policy_name" vs "name".  We will eventually completely remove "name", but this is just a tiny diff to update the example code.  There are no changes needed to the actual package itself.

## Motivation and Context
Feedback from design / adp customers.

## How Has This Been Tested?
I've run the example code successfully on an actual duo deployment and it works as expected.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Just an update to the example code / documentation. 😄 
