### PR TITLE
Add methods for bulk policy operations

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3404,10 +3404,11 @@ class Admin(client.Client):
 
         Args:
             sections (dict): policy content to update
-            sections_to_delete (array): List of section names to delete
-            edit_list (array): List of new policy keys to apply the changes to.
+            sections_to_delete (list): List of section names to delete
+            edit_list (list): List of new policy keys to apply the changes to.
                                Ignored if edit_all_policies is True.
-            edit_all_policies (bool, optional): Apply changes to all policies
+            edit_all_policies (bool, optional): Apply changes to all policies.
+                                Defaults to False. 
         Returns (list): all updated policies
         """
         path = "/admin/v2/policies/update"

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3340,6 +3340,32 @@ class Admin(client.Client):
         path = "/admin/v2/policies/" + self._quote_policy_id(policy_key)
         response = self.json_api_call("PUT", path, json_request)
         return response
+    
+    def update_policies_v2(self, sections, sections_to_delete, 
+                           edit_list, edit_all_policies=False):
+        """
+        Update the contents of multiple policies
+        Args:
+            sections (dict) - policy content to update
+            sections_to_delete (array) - List of section names to delete
+            edit_list (array) - List of new policy keys to apply the changes to.
+                                Ignored if edit_all_policies is True.
+            edit_all_policies (bool, optional) - Apply changes to all policies
+        Returns (list) - all updated policies
+        """
+        path = "/admin/v2/policies/update"
+        params = {
+            "policies_to_update": {
+                "edit_all_policies": edit_all_policies,
+                "edit_list": edit_list,
+            },
+            "policy_changes": {
+                "sections": sections,
+                "sections_to_delete": sections_to_delete,
+            },
+        }
+        response = self.json_api_call("PUT", path, params)
+        return response
 
     def create_policy_v2(self, json_request):
         """
@@ -3350,6 +3376,23 @@ class Admin(client.Client):
 
         path = "/admin/v2/policies"
         response = self.json_api_call("POST", path, json_request)
+        return response
+    
+    def copy_policy_v2(self, policy_key, new_policy_names_list):
+        """
+        Args:
+            policy_key (str) - Unique id of the policy to copy from
+            new_policy_names_list (array) - The policy specified by policy_key
+                                            will be copied once for each name
+                                            in the list
+        Returns (list) - all new policies
+        """
+        path = "/admin/v2/policies/copy"
+        params = {
+            "policy_key": policy_key, 
+            "new_policy_names_list": new_policy_names_list
+        }
+        response = self.json_api_call("POST", path, params)
         return response
 
     def get_policy_v2(self, policy_key):

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3344,14 +3344,15 @@ class Admin(client.Client):
     def update_policies_v2(self, sections, sections_to_delete, 
                            edit_list, edit_all_policies=False):
         """
-        Update the contents of multiple policies
+        Update the contents of multiple policies.
+
         Args:
-            sections (dict) - policy content to update
-            sections_to_delete (array) - List of section names to delete
-            edit_list (array) - List of new policy keys to apply the changes to.
-                                Ignored if edit_all_policies is True.
-            edit_all_policies (bool, optional) - Apply changes to all policies
-        Returns (list) - all updated policies
+            sections (dict): policy content to update
+            sections_to_delete (array): List of section names to delete
+            edit_list (array): List of new policy keys to apply the changes to.
+                               Ignored if edit_all_policies is True.
+            edit_all_policies (bool, optional): Apply changes to all policies
+        Returns (list): all updated policies
         """
         path = "/admin/v2/policies/update"
         params = {
@@ -3380,12 +3381,14 @@ class Admin(client.Client):
     
     def copy_policy_v2(self, policy_key, new_policy_names_list):
         """
+        Copy policy to multiple new policies.
+ 
         Args:
-            policy_key (str) - Unique id of the policy to copy from
-            new_policy_names_list (array) - The policy specified by policy_key
+            policy_key (str): Unique id of the policy to copy from
+            new_policy_names_list (array): The policy specified by policy_key
                                             will be copied once for each name
                                             in the list
-        Returns (list) - all new policies
+        Returns (list): all new policies
         """
         path = "/admin/v2/policies/copy"
         params = {

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -19,6 +19,7 @@ admin_api = duo_client.Admin(
     ikey=get_next_arg('Admin API integration key ("DI..."): '),
     skey=get_next_arg("integration secret key: "),
     host=get_next_arg('API hostname ("api-....duosecurity.com"): '),
+    ca_certs="DISABLE",
 )
 
 
@@ -59,6 +60,25 @@ def create_policy_browsers(name, print_response=False):
         print(pretty)
     return response.get("policy_key")
 
+def copy_policy(name1, name2, copy_from, print_response=False):
+    """
+    Copy the policy `copy_from` to two new policies.
+    """
+    response = admin_api.copy_policy_v2(copy_from, [name1, name2])
+    if print_response:
+        pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
+        print(pretty)
+    policies = response.get("policies")
+    return (policies[0].get("policy_key"), policies[1].get("policy_key"))
+
+def bulk_delete_section(policy_keys, print_response=False):
+    """
+    Delete the section "browsers" from the provided policies.
+    """
+    response = admin_api.update_policies_v2("", ["browsers"], policy_keys)
+    if print_response:
+        pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
+        print(pretty)
 
 def update_policy_with_device_health_app(policy_key, print_response=False):
     """
@@ -130,6 +150,12 @@ def main():
 
     # Create a policy with browser restriction settings.
     policy_key_d = create_policy_browsers("Test New Policy - d")
+
+    # Copy a policy to 2 new policies.
+    policy_key_e, policy_key_f = copy_policy("Test New Policy - e", "Test New Policy - f", policy_key_d)
+
+    # Delete the browser restriction settings from 2 policies.
+    bulk_delete_section([policy_key_e, policy_key_f])
 
     # Fetch the global and other custom policy.
     get_policy("global")

--- a/examples/policies.py
+++ b/examples/policies.py
@@ -19,7 +19,6 @@ admin_api = duo_client.Admin(
     ikey=get_next_arg('Admin API integration key ("DI..."): '),
     skey=get_next_arg("integration secret key: "),
     host=get_next_arg('API hostname ("api-....duosecurity.com"): '),
-    ca_certs="DISABLE",
 )
 
 

--- a/tests/admin/test_policies.py
+++ b/tests/admin/test_policies.py
@@ -39,6 +39,17 @@ class TestPolicies(TestAdmin):
         self.assertEqual(response["method"], "PUT")
         self.assertEqual(response["uri"], "/admin/v2/policies/{}".format(policy_key))
 
+    def test_update_policies_v2(self):
+        edit_list = ["POSTGY2G0HVWJR4JO1XT", "POSTGY2G0HVWJR4JO1XU"]
+        sections = {
+                "browsers": {
+                    "blocked_browsers_list": ["ie"],
+                }
+        }
+        response = self.client.update_policies_v2(sections, [], edit_list)
+        self.assertEqual(response["method"], "PUT")
+        self.assertEqual(response["uri"], "/admin/v2/policies/update")
+
     def test_create_policy_v2(self):
         policy_settings = {
             "name": "my new policy",
@@ -52,6 +63,14 @@ class TestPolicies(TestAdmin):
 
         self.assertEqual(response["method"], "POST")
         self.assertEqual(response["uri"], "/admin/v2/policies")
+
+    def test_copy_policy_v2(self):
+        policy_key = "POSTGY2G0HVWJR4JO1XT"
+        new_policy_names_list = ["Copied Pol 1", "Copied Pol 2"]
+        response = self.client.copy_policy_v2(policy_key, new_policy_names_list)
+
+        self.assertEqual(response["method"], "POST")
+        self.assertEqual(response["uri"], "/admin/v2/policies/copy")
 
     def test_get_policies_v2(self):
         response = self.client.get_policies_v2(limit=3, offset=0)


### PR DESCRIPTION
## Description
Add support for the bulk policy copy and update endpoints. 

## Motivation and Context
Updates python client to support all endpoints for the policy admin API. 

## How Has This Been Tested?
Added new tests, updated the existing policy example, tested in dev environment. 

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
