### PR TITLE
Stop claiming Py2 support in wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[bdist_wheel]
-# The code is written to work on both Python 2 and Python 3.
-universal=1
-
 [bdist_rpm]
 # Due to changes in Python's ConfigParser, this only works in Python 3. For Python 2, remove one %
 release=1%%{?dist}


### PR DESCRIPTION
## Description
Our build config file set the universal flag which indicates both Py2 and Py3 support - but we haven't supported Py2 for a while, so remove that.

## Motivation and Context
To correctly label the wheel file as Py3 only

## How Has This Been Tested?
Tested locally

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
