### PR TITLE
Remove reference to Py2 in the bdist build config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [bdist_rpm]
-# Due to changes in Python's ConfigParser, this only works in Python 3. For Python 2, remove one %
 release=1%%{?dist}
 requires=python-six


### PR DESCRIPTION
## Description
Remove a reference to Py2 in the build config since we don't support Py2 anymore

## Motivation and Context
To accurately represent our Python support

## How Has This Been Tested?
N/A just a comment

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
