### PR TITLE
fix accessing real example.com in test cases

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3530,15 +3530,18 @@ class AccountAdmin(Admin):
             if child_api_host is None:
                 child_api_host = kwargs.get('host')
                 try:
-                    accounts_api = Accounts(**kwargs)
-                    accounts_api.get_child_accounts()
-                    child_api_host =  Accounts.child_map.get(account_id, kwargs['host'])
+                    child_api_host =  self.get_child_api_host(account_id, **kwargs)
                 except RuntimeError:
                     pass
         kwargs['host'] = child_api_host
         
         super(AccountAdmin, self).__init__(**kwargs)
         self.account_id = account_id
+
+    def get_child_api_host(self, account_id, **kwargs):
+        accounts_api = Accounts(**kwargs)
+        accounts_api.get_child_accounts()
+        return Accounts.child_map.get(account_id, kwargs['host'])
 
     def get_edition(self):
         """

--- a/tests/accountAdmin/base.py
+++ b/tests/accountAdmin/base.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 from .. import util
 import duo_client.admin
 
@@ -6,9 +7,17 @@ import duo_client.admin
 class TestAccountAdmin(unittest.TestCase):
 
     def setUp(self):
-        kwargs = {'ikey': 'test_ikey', 'skey': 'test_skey', 'host': 'example.com', 'child_api_host': 'example2.com'}
+        child_host = 'example2.com'
+        kwargs = {'ikey': 'test_ikey', 'skey': 'test_skey', 'host': 'example.com'}
+
+        patcher = patch("duo_client.admin.AccountAdmin.get_child_api_host")
+        self.mock_child_host = patcher.start()
+        self.mock_child_host.return_value = child_host
+        self.addCleanup(patcher.stop)
+
         self.client = duo_client.admin.AccountAdmin(
             'DA012345678901234567', **kwargs)
+        
         # monkeypatch client's _connect()
         self.client._connect = lambda: util.MockHTTPConnection()
 


### PR DESCRIPTION
remove ssl certificate test failure bug - no longer accessing the real example.com

## Description
Factor out the code that causes the issue into a function and mock that function in the test cases.  Also, remove the temporary workaround.

## Motivation and Context
https://cisco-sbg.atlassian.net/browse/ZTMSP-771
context: https://duosecurity.slack.com/archives/CJCHMJDL7/p1707334317810179 

## How Has This Been Tested?
ran nose2 with and without the changes in base.py - without the mocks (and the temporary workaround has been removed) 5 test cases fail.  They pass with the mock.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

