### PR TITLE
Accounts API examples for interacting with child accounts via parent account APIs

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3530,15 +3530,18 @@ class AccountAdmin(Admin):
             if child_api_host is None:
                 child_api_host = kwargs.get('host')
                 try:
-                    accounts_api = Accounts(**kwargs)
-                    accounts_api.get_child_accounts()
-                    child_api_host =  Accounts.child_map.get(account_id, kwargs['host'])
+                    child_api_host =  self.get_child_api_host(account_id, **kwargs)
                 except RuntimeError:
                     pass
         kwargs['host'] = child_api_host
         
         super(AccountAdmin, self).__init__(**kwargs)
         self.account_id = account_id
+
+    def get_child_api_host(self, account_id, **kwargs):
+        accounts_api = Accounts(**kwargs)
+        accounts_api.get_child_accounts()
+        return Accounts.child_map.get(account_id, kwargs['host'])
 
     def get_edition(self):
         """

--- a/tests/accountAdmin/base.py
+++ b/tests/accountAdmin/base.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 from .. import util
 import duo_client.admin
 
@@ -6,9 +7,17 @@ import duo_client.admin
 class TestAccountAdmin(unittest.TestCase):
 
     def setUp(self):
-        kwargs = {'ikey': 'test_ikey', 'skey': 'test_skey', 'host': 'example.com', 'child_api_host': 'example2.com'}
+        child_host = 'example2.com'
+        kwargs = {'ikey': 'test_ikey', 'skey': 'test_skey', 'host': 'example.com'}
+
+        patcher = patch("duo_client.admin.AccountAdmin.get_child_api_host")
+        self.mock_child_host = patcher.start()
+        self.mock_child_host.return_value = child_host
+        self.addCleanup(patcher.stop)
+
         self.client = duo_client.admin.AccountAdmin(
             'DA012345678901234567', **kwargs)
+        
         # monkeypatch client's _connect()
         self.client._connect = lambda: util.MockHTTPConnection()
 


### PR DESCRIPTION
## Description

Two new examples for the Accounts API are proposed to illustrate both the extraction of existing application integrations from a child account via a parent account API as well as the creation of new application integrations in child accounts.

## Motivation and Context
This addition is in response to consumer feedback regarding the need for additional examples and documentation.

## How Has This Been Tested?
These examples were test for both success and failure scenarios against internal Duo accounts.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
