### PR TITLE
chore: remove admin API credentials from report_user_activity example

### DIFF
--- a/examples/Admin/report_user_activity.py
+++ b/examples/Admin/report_user_activity.py
@@ -8,40 +8,36 @@ import duo_client
 from six.moves import input
 
 argv_iter = iter(sys.argv[1:])
-def get_next_arg(prompt):
+
+
+def get_next_input(prompt):
+    """Collect user input from terminal and return it."""
     try:
         return next(argv_iter)
     except StopIteration:
         return input(prompt)
+
 
 def human_time(time: int) -> str:
     """Translate unix time into human readable string"""
     if time is None:
         date_str = 'Never'
     else:
-        date_str =  datetime.fromtimestamp(time, timezone.utc).strftime("%Y-%m-%m %H:%M:%S")
+        date_str = datetime.fromtimestamp(time, timezone.utc).strftime("%Y-%m-%m %H:%M:%S")
     return date_str
 
 
 # Configuration and information about objects to create.
-"""
 admin_api = duo_client.Admin(
-    ikey=get_next_input('Admin API integration key ("DI..."): '),
-    skey=get_next_input('integration secret key: '),
-    host=get_next_input('API hostname ("api-....duosecurity.com"): '),
-)
-"""
+        ikey=get_next_input('Admin API integration key ("DI..."): '),
+        skey=get_next_input('integration secret key: '),
+        host=get_next_input('API hostname ("api-....duosecurity.com"): '), )
 
-admin_api = duo_client.Admin(
-        ikey='DIW9XT14VIIAH3L427I8',
-        skey='8iQEKjOCxjjvwYKFZ77ztkcd60c7aToMlf8zZiDs',
-        host='api-731c6826.duosecurity.com'
-)
 # Retrieve user info from API:
 users = admin_api.get_users()
 
 print(f'{"Username":^30} {"Last Login":^20} {"User Enrolled"}')
-print(f'{"="*30} {"="*20} {"="*15}')
+print(f'{"=" * 30} {"=" * 20} {"=" * 15}')
 for user in users:
     line_out = f"{user['username']:30} "
     line_out += f"{human_time(user['last_login']):20} "


### PR DESCRIPTION
## Description
Remove Admin API test credentials mistakenly left in the report_user_activity.py example

## Motivation and Context
Although the API credentials are no longer valid, the script would not execute as expected without the normal user input prompts from the terminal.

## How Has This Been Tested?
Verified expected execution manually.

## Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
