### PR TITLE
Add txid in auth and client_supports_verified_push in preauth

### DIFF
--- a/duo_client/auth.py
+++ b/duo_client/auth.py
@@ -87,6 +87,7 @@ class Auth(client.Client):
                 username=None,
                 user_id=None,
                 ipaddr=None,
+                client_supports_verified_push=None,
                 trusted_device_token=None):
         """
         Determine if and with what factors a user may authenticate or enroll.
@@ -100,6 +101,8 @@ class Auth(client.Client):
             params['user_id'] = user_id
         if ipaddr is not None:
             params['ipaddr'] = ipaddr
+        if client_supports_verified_push is not None:
+            params['client_supports_verified_push'] = client_supports_verified_push
         if trusted_device_token is not None:
             params['trusted_device_token'] = trusted_device_token
         response = self.json_api_call('POST',
@@ -117,7 +120,8 @@ class Auth(client.Client):
              display_username=None,
              pushinfo=None,
              device=None,
-             passcode=None):
+             passcode=None,
+             txid=None):
         """
         Perform second-factor authentication for a user.
 
@@ -156,6 +160,8 @@ class Auth(client.Client):
             params['device'] = device
         if passcode is not None:
             params['passcode'] = passcode
+        if txid is not None:
+            params['txid'] = txid
         response = self.json_api_call('POST',
                                       '/auth/v2/auth',
                                       params)


### PR DESCRIPTION
In order to support verified push in auth API, we need to include these new parameters

## Description

- [x] Add a new parameter `client_supports_verified_push` in the `preauth` func
- [x] Add a new parameter `txid` in the `auth` func

## Motivation and Context
to support the Verified Push in the Auth API

## How Has This Been Tested?
Yes tested via this script https://github.com/cisco-sbg/ZT-trustedpath/pull/7053

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
