### PR TITLE
add enrollment_unversal_prompt_enabled to admin api settings

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -115,6 +115,7 @@ Settings objects are returned in the following format:
      'email_activity_notification_enabled': <bool:can users get activity notifications via email>,
      'push_activity_notification_enabled': <bool:can users get activity notifications via Duo Mobile>,
      'unenrolled_user_lockout_threshold': <int:days until a user will be locked out due to being unenrolled>,
+     'enrollment_universal_prompt_enabled': <bool:will email enrollment use Universal Prompt experience>,
     }
 
 
@@ -1987,6 +1988,7 @@ class Admin(client.Client):
                         email_activity_notification_enabled=None,
                         push_activity_notification_enabled=None,
                         unenrolled_user_lockout_threshold=None,
+                        enrollment_universal_prompt_enabled=None,
                         ):
         """
         Update settings.
@@ -2029,6 +2031,7 @@ class Admin(client.Client):
         email_activity_notification_enabled = True|False|None
         push_activity_notification_enabled = True|False|None
         unenrolled_user_lockout_threshold = <int:number of days>|0|None
+        enrollment_universal_prompt_enabled = True|False|None
 
         Returns updated settings object.
 
@@ -2115,6 +2118,10 @@ class Admin(client.Client):
         if unenrolled_user_lockout_threshold is not None:
             params['unenrolled_user_lockout_threshold'] = str(
                 unenrolled_user_lockout_threshold
+            )
+        if enrollment_universal_prompt_enabled is not None:
+            params['enrollment_universal_prompt_enabled'] = (
+                '1' if enrollment_universal_prompt_enabled else '0'
             )
 
         if not params:

--- a/tests/admin/test_settings.py
+++ b/tests/admin/test_settings.py
@@ -44,6 +44,7 @@ class TestSettings(TestAdmin):
             email_activity_notification_enabled=True,
             push_activity_notification_enabled=True,
             unenrolled_user_lockout_threshold=100,
+            enrollment_universal_prompt_enabled=True,
         )
         response = response[0]
         self.assertEqual(response['method'], 'POST')
@@ -85,4 +86,5 @@ class TestSettings(TestAdmin):
                 'email_activity_notification_enabled': '1',
                 'push_activity_notification_enabled': '1',
                 'unenrolled_user_lockout_threshold': '100',
+                'enrollment_universal_prompt_enabled': '1',
             })


### PR DESCRIPTION
Adds `enrollment_unversal_prompt_enabled` field to the admin settings endpoint

## Description
included the new field that can be set and returned when calling the admin settings endpoint

## Motivation and Context
We recently added the new field to adminapi openapi spec. The changes here are updating our settings endpoint to match the spec.
`enrollment_universal_prompt_enabled:
          description: >
            If true, email enrollment will use the Universal Prompt experience.
            If false, email enrollment will use the traditional Prompt experience.
          type: boolean`

## How Has This Been Tested?
updated `test_update_settings()` in `test_settings.py` to include the new field

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
