### PR TITLE
Add detections + assessment filter keys to valid authlog request params

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -208,6 +208,8 @@ VALID_AUTHLOG_REQUEST_PARAMS = [
     "groups",
     "factors",
     "api_version",
+    "assessment",
+    "detections",
 ]
 
 VALID_ACTIVITY_REQUEST_PARAMS = ["mintime", "maxtime", "limit", "sort", "next_offset"]


### PR DESCRIPTION
## Description
"detections" and "assessment" added to `VALID_AUTHLOG_REQUEST_PARAMS`

## Motivation and Context
These are new filter keys that can be used while querying for authlogs. 
"detections" filters on specific Risk-based Remembered Devices detections and Risk-based Factor Selection detections.
"assessment" filters on the effective Risk-based Authentication trust assessment result.
This information is displayed in the authlog report UI, so Kit should have the ability to filter on them through the admin API.

## How Has This Been Tested?
This was tested on the "RBA Sandbox" customer in the First environment (changes to include these filters are rolling out with D287).

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
