### PR TITLE
Pin cyclonedx dependency version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         pip install setuptools wheel twine six
     - name: Generate SBOM
       run: |
-        pip install cyclonedx-bom
+        pip install cyclonedx-bom==3.11.7
         cyclonedx-py --e --format json -o cyclonedx-sbom.json
     - name: Convert SBOM
       uses: duosecurity/duo_client_python/.github/actions/sbom-convert@master


### PR DESCRIPTION
## Description
This fixes a version incompatibility in our SBOM workflow.  See https://github.com/duosecurity/duo_universal_python/pull/25 for the analogous PR to duo_universal_python

## Motivation and Context
SBOM step is broken due to a major version incompatibility with the existing CLI invocation

## How Has This Been Tested?
Same fix as duo_universal_python

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
