### PR TITLE
Updating policy files to reflect the current Duo Desktop policy structure

### DIFF
--- a/examples/Admin/policies.py
+++ b/examples/Admin/policies.py
@@ -89,7 +89,6 @@ def update_policy_with_duo_desktop(policy_key, print_response=False):
             "duo_desktop": {
                 "enforce_encryption": ["windows"],
                 "enforce_firewall": ["windows"],
-                "prompt_to_install": ["windows"],
                 "requires_duo_desktop": ["windows"],
                 "windows_endpoint_security_list": ["cisco-amp"],
                 "windows_remediation_note": "Please install Windows agent",

--- a/examples/Admin/policies.py
+++ b/examples/Admin/policies.py
@@ -78,6 +78,14 @@ def bulk_delete_section(policy_keys, print_response=False):
         pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
         print(pretty)
 
+def update_policy_with_device_health_app(policy_key, print_response=False):
+    """
+    Update a given policy to include Duo Device Health App policy
+    settings. Requires Access or Beyond editions.
+    NOTE: this function is deprecated, please use update_policy_with_duo_desktop
+    """
+    return update_policy_with_duo_desktop(policy_key, print_response)
+
 def update_policy_with_duo_desktop(policy_key, print_response=False):
     """
     Update a given policy to include Duo Desktop policy

--- a/examples/Admin/policies.py
+++ b/examples/Admin/policies.py
@@ -78,19 +78,19 @@ def bulk_delete_section(policy_keys, print_response=False):
         pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
         print(pretty)
 
-def update_policy_with_device_health_app(policy_key, print_response=False):
+def update_policy_with_duo_desktop(policy_key, print_response=False):
     """
-    Update a given policy to include Duo Device Health App policy
+    Update a given policy to include Duo Desktop policy
     settings. Requires Access or Beyond editions.
     """
 
     json_request = {
         "sections": {
-            "device_health_app": {
+            "duo_desktop": {
                 "enforce_encryption": ["windows"],
                 "enforce_firewall": ["windows"],
                 "prompt_to_install": ["windows"],
-                "requires_DHA": ["windows"],
+                "requires_duo_desktop": ["windows"],
                 "windows_endpoint_security_list": ["cisco-amp"],
                 "windows_remediation_note": "Please install Windows agent",
             },
@@ -139,8 +139,8 @@ def main():
     policy_key_a = create_empty_policy("Test New Policy - a")
     policy_key_b = create_empty_policy("Test New Policy - b")
 
-    # Update policy with Duo Device Health App settings.
-    update_policy_with_device_health_app(policy_key_b)
+    # Update policy with Duo Desktop settings.
+    update_policy_with_duo_desktop(policy_key_b)
 
     # Create an empty policy and delete it.
     policy_key_c = create_empty_policy("Test New Policy - c")

--- a/examples/Admin/policies_advanced.py
+++ b/examples/Admin/policies_advanced.py
@@ -86,19 +86,19 @@ def bulk_delete_section(policy_keys, print_response=False):
         print(pretty)
 
 
-def update_policy_with_device_health_app(policy_key, print_response=False):
+def update_policy_with_duo_desktop(policy_key, print_response=False):
     """
-    Update a given policy to include Duo Device Health App policy
+    Update a given policy to include Duo Desktop policy
     settings. Requires Access or Beyond editions.
     """
 
     json_request = {
             "sections": {
-                    "device_health_app": {
+                    "duo_desktop": {
                             "enforce_encryption":             ["windows"],
                             "enforce_firewall":               ["windows"],
                             "prompt_to_install":              ["windows"],
-                            "requires_DHA":                   ["windows"],
+                            "requires_duo_desktop":           ["windows"],
                             "windows_endpoint_security_list": ["cisco-amp"],
                             "windows_remediation_note":       "Please install Windows agent",
                     },
@@ -148,8 +148,8 @@ def main():
     policy_key_a = create_empty_policy("Test New Policy - a")
     policy_key_b = create_empty_policy("Test New Policy - b")
 
-    # Update policy with Duo Device Health App settings.
-    update_policy_with_device_health_app(policy_key_b)
+    # Update policy with Duo Desktop settings.
+    update_policy_with_duo_desktop(policy_key_b)
 
     # Create an empty policy and delete it.
     policy_key_c = create_empty_policy("Test New Policy - c")

--- a/examples/Admin/policies_advanced.py
+++ b/examples/Admin/policies_advanced.py
@@ -97,7 +97,6 @@ def update_policy_with_duo_desktop(policy_key, print_response=False):
                     "duo_desktop": {
                             "enforce_encryption":             ["windows"],
                             "enforce_firewall":               ["windows"],
-                            "prompt_to_install":              ["windows"],
                             "requires_duo_desktop":           ["windows"],
                             "windows_endpoint_security_list": ["cisco-amp"],
                             "windows_remediation_note":       "Please install Windows agent",

--- a/examples/Admin/policies_advanced.py
+++ b/examples/Admin/policies_advanced.py
@@ -85,6 +85,13 @@ def bulk_delete_section(policy_keys, print_response=False):
         pretty = json.dumps(response, indent=4, sort_keys=True, default=str)
         print(pretty)
 
+def update_policy_with_device_health_app(policy_key, print_response=False):
+    """
+    Update a given policy to include Duo Device Health App policy
+    settings. Requires Access or Beyond editions.
+    NOTE: this function is deprecated, please use update_policy_with_duo_desktop
+    """
+    return update_policy_with_duo_desktop(policy_key, print_response)
 
 def update_policy_with_duo_desktop(policy_key, print_response=False):
     """


### PR DESCRIPTION
## Description
The device_health_app section of the policy API was updated to duo_desktop, with one variable renamed (requires_DHA -> requires_duo_desktop) last year, but the two policy examples that use it were not updated alongside it. This PR updates those two values, and also renames the functions that use them to say Duo Desktop instead of Device Health App.

## Motivation and Context
This ensures that the current example for Duo Desktop policy is accurate and reflects the name change the Device Health App had last year.

## How Has This Been Tested?
Ran both policies and policies_advanced locally to ensure the policy was created correctly and updated with the correct Duo Desktop policies in my admin panel UI

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
