### PR TITLE
correcting path in usage section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the `examples` folder for how to use this library.
 
 To run an example query, execute a command like the following from the repo root:
 ```
-$ python examples/report_users_and_phones.py
+$ python examples/Admin/report_users_and_phones.py
 ```
 
 # Testing


### PR DESCRIPTION
## Description
Usage section in READ.me appears to point to an old path. See [Issue 270](https://github.com/duosecurity/duo_client_python/issues/270)

## Expected Behavior

$ python examples/Admin/report_users_and_phones.py

## Actual Behavior
$ python examples/report_users_and_phones.py

## Steps to Reproduce
n/a

## Workarounds
n/a