### PR TITLE
feat: add get_passport_config() to client.Admin

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -174,14 +174,15 @@ the following fields:
            {"code": 40401, "message": "Resource not found", "stat": "FAIL"}
 """
 
-from . import client, Accounts
-from .logs.telephony import Telephony
-import warnings
+import base64
 import json
 import time
-import base64
 import urllib.parse
+import warnings
 from datetime import datetime, timedelta, timezone
+
+from . import Accounts, client
+from .logs.telephony import Telephony
 
 USER_STATUS_ACTIVE = "active"
 USER_STATUS_BYPASS = "bypass"
@@ -3532,6 +3533,15 @@ class Admin(client.Client):
         """
 
         path = "/admin/v2/policies/summary"
+        response = self.json_api_call("GET", path, {})
+        return response
+
+    def get_passport_config(self):
+        """
+        Returns the current Passport configuration.
+        """
+
+        path = "/admin/v2/passport/config"
         response = self.json_api_call("GET", path, {})
         return response
 

--- a/tests/admin/test_passport.py
+++ b/tests/admin/test_passport.py
@@ -1,0 +1,13 @@
+from .base import TestAdmin
+from .. import util
+
+
+class TestPassport(TestAdmin):
+    def test_get_passport(self):
+        """ Test get passport configuration
+        """
+        response = self.client.get_passport_config()
+        (uri, args) = response['uri'].split('?')
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v2/passport/config')
+        self.assertEqual(util.params_to_dict(args), {'account_id': [self.client.account_id]})


### PR DESCRIPTION
Tested-by: new test case in tests/test_passport.py

## Description
Add new get_passport_config() method to client.Admin to accommodate the recent addition to the Admin API

## Motivation and Context
Ensure continued parity between the documented public Admin API endpoints and library functionality

## How Has This Been Tested?
New test case test_passport.py was added to validate the new method

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
