### PR TITLE
feat: add desktop authenticators methods to client.Admin

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -1605,21 +1605,74 @@ class Admin(client.Client):
             params['installation_msg'] = installation_msg
         return self.json_api_call('POST', path, params)
 
+    def get_desktop_authenticators_generator(self):
+        """
+        Returns a generator yielding desktop_authenticators.
+        """
+        return self.json_paging_api_call(
+            'GET', '/admin/v1/desktop_authenticators',
+            {}
+        )
+
+    def get_desktop_authenticators(self, limit=None, offset=0):
+        """
+        Retrieves a list of desktop authenticators.
+        Args:
+            limit: The max number of desktop authenticators to fetch at once. Default None
+            offset: If a limit is passed, the offset to start retrieval.
+                    Default 0
+
+        Returns: list of desktop authenticators
+
+        Raises RuntimeError on error.
+
+        """
+        (limit, offset) = self.normalize_paging_args(limit, offset)
+        if limit:
+            return self.json_api_call('GET', '/admin/v1/desktop_authenticators', {'limit': limit, 'offset': offset})
+
+        return list(self.get_desktop_authenticators_generator())
+
+    def get_desktop_authenticator_by_key(self, desktop_authenticator_key):
+        """
+        Returns a desktop authenticator specified by desktop_authenticator_key.
+
+        desktop_authenticator_key - Desktop Authenticator Key (dakey)
+
+        Returns desktop authenticator object.
+
+        Raises RuntimeError on error.
+        """
+        path = '/admin/v1/desktop_authenticators/' + desktop_authenticator_key
+        response = self.json_api_call('GET', path, {})
+        return response
+
+    def delete_desktop_authenticator(self, desktop_authenticator_key):
+        """
+        Deletes a desktop authenticator. If the desktop authenticator has already been deleted,
+        does nothing.
+
+        desktop_authenticator_key - Desktop token ID.
+
+        Returns nothing.
+
+        Raises RuntimeError on error.
+        """
+        path = '/admin/v1/desktop_authenticators/' + urllib.parse.quote_plus(desktop_authenticator_key)
+        params = {}
+        return self.json_api_call('DELETE', path, params)
+
     def get_desktoptokens_generator(self):
         """
         Returns a generator yielding desktoptokens.
         """
-        return self.json_paging_api_call(
-            'GET',
-            '/admin/v1/desktoptokens',
-            {}
-        )
+        return self.json_paging_api_call('GET', '/admin/v1/desktoptokens', {})
 
     def get_desktoptokens(self, limit=None, offset=0):
         """
         Retrieves a list of desktoptokens.
         Args:
-            limit: The max number of admins to fetch at once. Default None
+            limit: The max number of desktoptokens to fetch at once. Default None
             offset: If a limit is passed, the offset to start retrieval.
                     Default 0
 

--- a/tests/admin/test_desktop_authenticators.py
+++ b/tests/admin/test_desktop_authenticators.py
@@ -1,0 +1,60 @@
+from .base import TestAdmin
+from .. import util
+
+
+class TestDesktopAuthenticators(TestAdmin):
+    def test_get_desktop_authenticators_generator(self):
+        """ Test to get desktop authenticators generator.
+        """
+        generator = self.client_list.get_desktop_authenticators_generator()
+        response = next(generator)
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/desktop_authenticators')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['100'], 'offset': ['0'], })
+
+    def test_get_desktop_authenticators(self):
+        """ Test to get desktop authenticators without params.
+        """
+        response = self.client_list.get_desktop_authenticators()[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/desktop_authenticators')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['100'], 'offset': ['0'], })
+
+    def test_get_desktop_authenticators_limit(self):
+        """ Test to get desktop authenticators with limit.
+        """
+        response = self.client_list.get_desktop_authenticators(limit='20')[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/desktop_authenticators')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['20'], 'offset': ['0'], })
+
+    def test_get_desktop_authenticators_offset(self):
+        """ Test to get desktop authenticators with offset.
+        """
+        response = self.client_list.get_desktop_authenticators(offset='20')[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/desktop_authenticators')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['100'], 'offset': ['0'], })
+
+    def test_get_desktop_authenticators_limit_offset(self):
+        """ Test to get desktop authenticators with limit and offset.
+        """
+        response = self.client_list.get_desktop_authenticators(limit='20', offset='2')[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/desktop_authenticators')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['20'], 'offset': ['2'], })


### PR DESCRIPTION
Tested-by: new test case in tests/admin/test_desktop_authenticators.py

## Description
Added the following new methods to support usage of the /admin/v1/desktop_authenticators endpoint

- get_desktop_authenticators_generator()
- get_desktop_authenticators()
- get_desktop_authenticator_by_key()
- delete_desktop_authenticator()

## Motivation and Context
Added new methods to maintain consistency with current Admin API functionality and documentation.

## How Has This Been Tested?
New tests added via tests/admin/test_desktop_authenticators.py

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
