### PR TITLE
feat: add registered_devices methods to client.Admin

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -2669,7 +2669,70 @@ class Admin(client.Client):
         )
         return response
 
-    def get_secret_key (self, integration_key):
+    def get_registered_devices_generator(self):
+        """
+        Returns a generator yielding Duo Desktop registered devices.
+        """
+        return self.json_paging_api_call('GET', '/admin/v1/registered_devices', {})
+
+    def get_registered_devices(self, limit=None, offset=0):
+        """
+        Retrieves a list of Duo Desktop registered devices.
+
+        Args:
+            limit: The max number of registered devices to fetch at once. [Default: None]
+            offset: If a 'limit' is passed, the offset to start retrieval.
+                    [Default: 0]
+
+        Returns:
+            list of registered devices
+
+        Raises:
+            RuntimeError on error.
+
+        """
+        (limit, offset) = self.normalize_paging_args(limit, offset)
+        if limit:
+            return self.json_api_call('GET', '/admin/v1/registered_devices', {'limit': limit, 'offset': offset})
+
+        return list(self.get_registered_devices_generator())
+
+    def get_registered_device_by_id(self, registered_device_id):
+        """
+        Returns a Duo Desktop registered device specified by registered_device_id (compkey).
+
+        Args:
+            registered_device_id - Duo Desktop registered device compkey
+
+        Returns:
+            registered device object.
+
+        Raises:
+             RuntimeError on error.
+        """
+        path = '/admin/v1/registered_devices/' + registered_device_id
+        response = self.json_api_call('GET', path, {})
+        return response
+
+    def delete_registered_device(self, registered_device_id):
+        """
+        Deletes a Duo Desktop registered device. If the registered device has already been deleted,
+        does nothing.
+
+        Args:
+            registered_device_id - Duo Desktop registered device ID (compkey).
+
+        Returns:
+             None
+
+        Raises:
+             RuntimeError on error.
+        """
+        path = '/admin/v1/registered_devices/' + urllib.parse.quote_plus(registered_device_id)
+        params = {}
+        return self.json_api_call('DELETE', path, params)
+
+    def get_secret_key(self, integration_key):
         """Returns the secret key of the specified integration.
 
         integration_key - The ikey of the secret key to get.

--- a/tests/admin/test_registered_devices.py
+++ b/tests/admin/test_registered_devices.py
@@ -1,0 +1,70 @@
+from .base import TestAdmin
+from .. import util
+
+
+class TestRegisteredDevices(TestAdmin):
+    def test_get_registered_devices_generator(self):
+        """ Test to get desktop tokens generator.
+        """
+        generator = self.client_list.get_registered_devices_generator()
+        response = next(generator)
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/registered_devices')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['100'], 'offset': ['0'], })
+
+    def test_get_registered_devices(self):
+        """ Test to get desktop tokens without params.
+        """
+        response = self.client_list.get_registered_devices()[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/registered_devices')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['100'], 'offset': ['0'], })
+
+    def test_get_registered_devices_limit(self):
+        """ Test to get desktop tokens with limit.
+        """
+        response = self.client_list.get_registered_devices(limit='20')[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/registered_devices')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['20'], 'offset': ['0'], })
+
+    def test_get_registered_devices_offset(self):
+        """ Test to get desktop tokens with offset.
+        """
+        response = self.client_list.get_registered_devices(offset='20')[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/registered_devices')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['100'], 'offset': ['0'], })
+
+    def test_get_registered_devices_limit_offset(self):
+        """ Test to get desktop tokens with limit and offset.
+        """
+        response = self.client_list.get_registered_devices(limit='20', offset='2')[0]
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'GET')
+        self.assertEqual(uri, '/admin/v1/registered_devices')
+        self.assertEqual(util.params_to_dict(args),
+                {'account_id': [self.client_list.account_id], 'limit': ['20'], 'offset': ['2'], })
+
+    def test_delete_registered_device(self):
+        """ Test to delete registered device by registered device id.
+        """
+        response = self.client.delete_registered_device('CRSFWW1YWVNUXMBJ1J29')
+        uri, args = response['uri'].split('?')
+
+        self.assertEqual(response['method'], 'DELETE')
+        self.assertEqual(uri, '/admin/v1/registered_devices/CRSFWW1YWVNUXMBJ1J29')
+        self.assertEqual(util.params_to_dict(args), {'account_id': [self.client.account_id]})


### PR DESCRIPTION
feat: add registered_devices methods to client.Admin
Tested-by: new test case in tests/admin/test_registered_devices.py

## Description
Add new methods for administering Duo Desktop registered devices to the Admin client

## Motivation and Context
Expand client library functionality to more closely match available API endpoints

## How Has This Been Tested?
Tested via new automated test cases defined in `tests/admin/test_registered_devices.py`

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
