### PR TITLE
Cast limit in get_authentication_log to a string

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -517,6 +517,8 @@ class Admin(client.Client):
             # Sanity check maxtime as unix timestamp, then transform to string
             params['maxtime'] = '{:d}'.format(int(params['maxtime']))
 
+            if "limit" in params:
+                params["limit"] = f"{int(params['limit'])}"
 
         response = self.json_api_call(
             'GET',


### PR DESCRIPTION
The API endpoint expects limit to be a string.

Cast the limit to a sting before sending off the API request

## Description
Cast the limit to a sting before sending off the API request

## Motivation and Context
A user of the api lib would reasonably expect a limit to be an int, not a string. Arguable the endpoint will probably cast this back to an int straight away :)

## How Has This Been Tested?
Locally tested

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
