### PR TITLE
feat: add custom_supported_browsers to update_passport_config() in ad…

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3677,7 +3677,7 @@ class Admin(client.Client):
         response = self.json_api_call("GET", path, {})
         return response
 
-    def update_passport_config(self, enabled_status, enabled_groups=[], disabled_groups=[]):
+    def update_passport_config(self, enabled_status, enabled_groups=[], disabled_groups=[], custom_supported_browsers={"macos": [], "windows": [],}):
         """
         Update the current Passport configuration.
 
@@ -3688,6 +3688,8 @@ class Admin(client.Client):
                 list of user group IDs for whom Passport should be enabled
             disabled_groups (list[str]) - if enabled_status is "enabled-with-exceptions",
                 a list of user group IDs for whom Passport should be disabled
+            custom_supported_browsers (dict) - a dict of criteria that determines whether 
+                a Windows or macOS browsers should be supported by Passport
         """
 
         path = "/admin/v2/passport/config"
@@ -3698,6 +3700,7 @@ class Admin(client.Client):
                 "enabled_status": enabled_status,
                 "enabled_groups": enabled_groups,
                 "disabled_groups": disabled_groups,
+                "custom_supported_browsers": custom_supported_browsers,
             },
         )
         return response

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3693,7 +3693,7 @@ class Admin(client.Client):
                 a Windows or macOS browsers should be supported by Passport
         """
         if custom_supported_browsers == None:
-            custom_supported_browsers={"macos": [], "windows": [],}
+            custom_supported_browsers = {"macos": [], "windows": [],}
 
         path = "/admin/v2/passport/config"
         response = self.json_api_call(

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -3692,7 +3692,7 @@ class Admin(client.Client):
             custom_supported_browsers (dict) - a dict of criteria that determines whether 
                 a Windows or macOS browsers should be supported by Passport
         """
-        if custom_supported_browsers == None:
+        if custom_supported_browsers is None:
             custom_supported_browsers = {"macos": [], "windows": [],}
 
         path = "/admin/v2/passport/config"

--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -178,6 +178,7 @@ import json
 import time
 import urllib.parse
 import warnings
+from typing import List, Optional
 from datetime import datetime, timedelta, timezone
 
 from . import Accounts, client
@@ -3677,7 +3678,7 @@ class Admin(client.Client):
         response = self.json_api_call("GET", path, {})
         return response
 
-    def update_passport_config(self, enabled_status, enabled_groups=[], disabled_groups=[], custom_supported_browsers={"macos": [], "windows": [],}):
+    def update_passport_config(self, enabled_status, enabled_groups: Optional[List[str]]=None, disabled_groups: Optional[List[str]]=None, custom_supported_browsers=None):
         """
         Update the current Passport configuration.
 
@@ -3691,6 +3692,8 @@ class Admin(client.Client):
             custom_supported_browsers (dict) - a dict of criteria that determines whether 
                 a Windows or macOS browsers should be supported by Passport
         """
+        if custom_supported_browsers == None:
+            custom_supported_browsers={"macos": [], "windows": [],}
 
         path = "/admin/v2/passport/config"
         response = self.json_api_call(

--- a/tests/admin/test_passport.py
+++ b/tests/admin/test_passport.py
@@ -22,5 +22,5 @@ class TestPassport(TestAdmin):
         body = json.loads(response["body"])
         self.assertEqual(body["enabled_status"], "enabled-for-groups")
         self.assertEqual(body["enabled_groups"], ["passport-test-group"])
-        self.assertEqual(body["disabled_groups"], [])
+        self.assertEqual(body["disabled_groups"], None)
         self.assertEqual(body["custom_supported_browsers"], {"macos":[{"team_id":"UBF8T346G9"}],"windows":[{"common_name":"Duo Security LLC"}]})

--- a/tests/admin/test_passport.py
+++ b/tests/admin/test_passport.py
@@ -17,9 +17,10 @@ class TestPassport(TestAdmin):
     def test_update_passport(self):
         """ Test update passport configuration
         """
-        response = self.client.update_passport_config(enabled_status="enabled-for-groups", enabled_groups=["passport-test-group"])
+        response = self.client.update_passport_config(enabled_status="enabled-for-groups", enabled_groups=["passport-test-group"], custom_supported_browsers={"macos": [{"team_id": "UBF8T346G9"},],"windows": [{"common_name": "Duo Security LLC"},],})
         self.assertEqual(response["uri"], "/admin/v2/passport/config")
         body = json.loads(response["body"])
         self.assertEqual(body["enabled_status"], "enabled-for-groups")
         self.assertEqual(body["enabled_groups"], ["passport-test-group"])
         self.assertEqual(body["disabled_groups"], [])
+        self.assertEqual(body["custom_supported_browsers"], {"macos":[{"team_id":"UBF8T346G9"}],"windows":[{"common_name":"Duo Security LLC"}]})

--- a/tests/admin/test_passport.py
+++ b/tests/admin/test_passport.py
@@ -17,7 +17,7 @@ class TestPassport(TestAdmin):
     def test_update_passport(self):
         """ Test update passport configuration
         """
-        response = self.client.update_passport_config(enabled_status="enabled-for-groups", enabled_groups=["passport-test-group"], custom_supported_browsers={"macos": [{"team_id": "UBF8T346G9"},],"windows": [{"common_name": "Duo Security LLC"},],})
+        response = self.client.update_passport_config(enabled_status="enabled-for-groups", enabled_groups=["passport-test-group"], custom_supported_browsers={"macos": [{"team_id": "UBF8T346G9"},], "windows": [{"common_name": "Duo Security LLC"},],})
         self.assertEqual(response["uri"], "/admin/v2/passport/config")
         body = json.loads(response["body"])
         self.assertEqual(body["enabled_status"], "enabled-for-groups")


### PR DESCRIPTION
Add custom_supported_browsers to update_passport_config() in admin.py

Update update_passport_config method with  custom_supported_browsers as a criteria that determines whether a Windows or macOS browsers should be supported by Passport

## Description
add custom_supported_browsers as new criteria  for update of the current Passport configuration

## Motivation and Context
duo_client_python was modified with custom_supported_browsers in https://github.com/cisco-sbg/ZT-trustedpath/pull/23553, so there is a need to have same changes in https://github.com/duosecurity/duo_client_python 

## How Has This Been Tested?
add test case  for custom_supported_browsers in existing test_update_passport test in test_passport.py

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
