### PR TITLE
Upgrade SBOM tooling for Python 3.13+ support

### DIFF
--- a/.github/actions/sbom-convert/action.yml
+++ b/.github/actions/sbom-convert/action.yml
@@ -4,7 +4,7 @@ runs:
   steps:
     - name: Install CycloneDX
       run: |
-        wget https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+        wget https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.30.0/cyclonedx-linux-x64
         chmod a+x cyclonedx-linux-x64
       shell: bash
     - name: Convert SBOM

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
         pip install setuptools wheel twine
     - name: Generate SBOM
       run: |
-        pip install cyclonedx-bom==3.11.7
-        cyclonedx-py --e --format json -o cyclonedx-sbom.json
+        pip install cyclonedx-bom==7.2.2
+        cyclonedx-py environment -o cyclonedx-sbom.json
     - name: Convert SBOM
       uses: duosecurity/duo_client_python/.github/actions/sbom-convert@master
     - name: Build and publish


### PR DESCRIPTION
## Summary

- **`cyclonedx-bom`** 3.11.7 → 7.2.2 — the 3.x series doesn't support Python 3.13, blocking releases on newer Python versions
- **`cyclonedx-cli`** v0.24.2 → v0.30.0 — picks up CycloneDX v1.7 / SPDX 2.3 compatibility
- **GitHub Actions** `actions/checkout` v2 → v4, `actions/setup-python` v2 → v5

## Details

### cyclonedx-bom CLI change

The 4.x release of `cyclonedx-bom` introduced breaking CLI changes — the `--e` flag became the `environment` subcommand and JSON became the default output format:

| | Old (3.x) | New (7.x) |
|---|---|---|
| Command | `cyclonedx-py --e --format json -o cyclonedx-sbom.json` | `cyclonedx-py environment -o cyclonedx-sbom.json` |

### cyclonedx-cli (sbom-convert composite action)

The download URL is bumped from v0.24.2 to v0.30.0. The `convert` command flags are identical between versions, so this is safe for downstream consumers of the composite action (duo_hmac_python, duo_universal_java, duo_client_java).

### GitHub Actions

`actions/checkout@v2` and `actions/setup-python@v2` are bumped to v4 and v5 respectively — the v2 versions use deprecated Node.js runtimes.

## Test plan

- [x] Install `cyclonedx-bom==7.2.2` locally, run `cyclonedx-py environment -o cyclonedx-sbom.json`, verify valid JSON output
- [x] Download `cyclonedx-cli` v0.30.0 and run the convert command on the generated JSON to verify spdx.json is produced
- [ ] The publish workflow only triggers on release creation, so the PR itself won't exercise the SBOM step — local testing is the primary verification method