### PR TITLE
Added read only permissions to duo-client

### DIFF
--- a/duo_client/admin.py
+++ b/duo_client/admin.py
@@ -126,9 +126,11 @@ Integration objects are returned in the following format:
     {'adminapi_admins': <bool:admins permission (0|1)>,
      'adminapi_info': <bool:info permission (0|1)>,
      'adminapi_integrations': <bool:integrations permission (0|1)>,
+     'adminapi_integrations_read': <bool:integrations read permission (0|1)>,
      'adminapi_read_log': <bool:read log permission (0|1)>,
      'adminapi_read_resource': <bool:read resource permission (0|1)>,
      'adminapi_settings': <bool:settings permission (0|1)>,
+     'adminapi_settings_read': <bool:settings read permission (0|1)>,
      'adminapi_write_resource': <bool:write resource permission (0|1)>,
      'self_service_allowed': <bool:self service permission (0|1)>,
      'enroll_policy': <str:enroll policy (enroll|allow|deny)>,
@@ -2624,12 +2626,16 @@ class Admin(client.Client):
                            enroll_policy=None,
                            username_normalization_policy=None,
                            adminapi_admins=None,
+                           adminapi_admins_read=None,
                            adminapi_info=None,
                            adminapi_integrations=None,
+                           adminapi_integrations_read=None,
                            adminapi_read_log=None,
                            adminapi_read_resource=None,
                            adminapi_settings=None,
+                           adminapi_settings_read=None,
                            adminapi_write_resource=None,
+                           adminapi_allow_to_set_permissions=None,
                            trusted_device_days=None,
                            ip_whitelist=None,
                            ip_whitelist_enroll_policy=None,
@@ -2655,9 +2661,11 @@ class Admin(client.Client):
         adminapi_admins - <bool: admins permission>|None
         adminapi_info - <bool: info permission>|None
         adminapi_integrations - <bool:integrations permission>|None
+        adminapi_integrations_read - <bool:integrations read permission>|None
         adminapi_read_log - <bool:read log permission>|None
         adminapi_read_resource - <bool: read resource permission>|None
         adminapi_settings - <bool: settings permission>|None
+        adminapi_settings_read - <bool:settings read permission>|None
         adminapi_write_resource - <bool:write resource permission>|None
         groups_allowed - <str: CSV list of gkeys of groups allowed to auth>
         self_service_allowed - <bool: self service permission>|None
@@ -2693,10 +2701,14 @@ class Admin(client.Client):
             params['ip_whitelist_enroll_policy'] = ip_whitelist_enroll_policy
         if adminapi_admins is not None:
             params['adminapi_admins'] = '1' if adminapi_admins else '0'
+        if adminapi_admins_read is not None:
+            params['adminapi_admins_read'] = '1' if adminapi_admins_read else '0'
         if adminapi_info is not None:
             params['adminapi_info'] = '1' if adminapi_info else '0'
         if adminapi_integrations is not None:
             params['adminapi_integrations'] = '1' if adminapi_integrations else '0'
+        if adminapi_integrations_read is not None:
+            params['adminapi_integrations_read'] = '1' if adminapi_integrations_read else '0'
         if adminapi_read_log is not None:
             params['adminapi_read_log'] = '1' if adminapi_read_log else '0'
         if adminapi_read_resource is not None:
@@ -2704,9 +2716,13 @@ class Admin(client.Client):
                 '1' if adminapi_read_resource else '0')
         if adminapi_settings is not None:
             params['adminapi_settings'] = '1' if adminapi_settings else '0'
+        if adminapi_settings_read is not None:
+            params['adminapi_settings_read'] = '1' if adminapi_settings_read else '0'
         if adminapi_write_resource is not None:
             params['adminapi_write_resource'] = (
                 '1' if adminapi_write_resource else '0')
+        if adminapi_allow_to_set_permissions is not None:
+            params['adminapi_allow_to_set_permissions'] = '1' if adminapi_allow_to_set_permissions else '0'
         if groups_allowed is not None:
             params['groups_allowed'] = groups_allowed
         if self_service_allowed is not None:
@@ -2827,11 +2843,14 @@ class Admin(client.Client):
                            enroll_policy=None,
                            username_normalization_policy=None,
                            adminapi_admins=None,
+                           adminapi_admins_read=None,
                            adminapi_info=None,
                            adminapi_integrations=None,
+                           adminapi_integrations_read=None,
                            adminapi_read_log=None,
                            adminapi_read_resource=None,
                            adminapi_settings=None,
+                           adminapi_settings_read=None,
                            adminapi_write_resource=None,
                            reset_secret_key=None,
                            trusted_device_days=None,
@@ -2856,11 +2875,14 @@ class Admin(client.Client):
         ip_whitelist_enroll_policy - <bool: policy>
                                      See adminapi docs for more details.
         adminapi_admins - <int:0|1>|None
+        adminapi_admins_read - True|False|None
         adminapi_info - True|False|None
         adminapi_integrations - True|False|None
+        adminapi_integrations_read - True|False|None
         adminapi_read_log - True|False|None
         adminapi_read_resource - True|False|None
         adminapi_settings - True|False|None
+        adminapi_settings_read - True|False|None
         adminapi_write_resource - True|False|None
         reset_secret_key - <any value>|None
         groups_allowed - <str: CSV list of gkeys of groups allowed to auth>
@@ -2901,10 +2923,14 @@ class Admin(client.Client):
             params['ip_whitelist_enroll_policy'] = ip_whitelist_enroll_policy
         if adminapi_admins is not None:
             params['adminapi_admins'] = '1' if adminapi_admins else '0'
+        if adminapi_admins_read is not None:
+            params['adminapi_admins_read'] = '1' if adminapi_admins_read else '0'
         if adminapi_info is not None:
             params['adminapi_info'] = '1' if adminapi_info else '0'
         if adminapi_integrations is not None:
             params['adminapi_integrations'] = '1' if adminapi_integrations else '0'
+        if adminapi_integrations_read is not None:
+            params['adminapi_integrations_read'] = '1' if adminapi_integrations_read else '0'
         if adminapi_read_log is not None:
             params['adminapi_read_log'] = '1' if adminapi_read_log else '0'
         if adminapi_read_resource is not None:
@@ -2912,6 +2938,8 @@ class Admin(client.Client):
                 '1' if adminapi_read_resource else '0')
         if adminapi_settings is not None:
             params['adminapi_settings'] = '1' if adminapi_settings else '0'
+        if adminapi_settings_read is not None:
+            params['adminapi_settings_read'] = '1' if adminapi_settings_read else '0'
         if adminapi_write_resource is not None:
             params['adminapi_write_resource'] = (
                 '1' if adminapi_write_resource else '0')

--- a/tests/admin/test_integration.py
+++ b/tests/admin/test_integration.py
@@ -76,5 +76,125 @@ class TestIntegration(TestAdmin):
             }
         )
 
+    def test_create_integration_with_permissions(self):
+        response = self.client.create_integration(
+            name="Admin API integration",
+            integration_type="adminapi",
+            adminapi_admins=True,
+            adminapi_admins_read=True,
+            adminapi_info=True,
+            adminapi_integrations=True,
+            adminapi_integrations_read=True,
+            adminapi_read_log=True,
+            adminapi_read_resource=True,
+            adminapi_settings=True,
+            adminapi_settings_read=True,
+            adminapi_write_resource=True,
+            adminapi_allow_to_set_permissions=True,
+            self_service_allowed=True,
+        )
+
+        self.assertEqual(response['method'], 'POST')
+        self.assertEqual(response['uri'], '/admin/v3/integrations')
+        self.assertEqual(json.loads(response['body']),
+            {
+                "account_id": self.client.account_id,
+                "name": "Admin API integration",
+                "type": "adminapi",
+                "adminapi_admins": "1",
+                "adminapi_admins_read": "1",
+                "adminapi_info": "1",
+                "adminapi_integrations": "1",
+                "adminapi_integrations_read": "1",
+                "adminapi_read_log": "1",
+                "adminapi_read_resource": "1",
+                "adminapi_settings": "1",
+                "adminapi_settings_read": "1",
+                "adminapi_write_resource": "1",
+                "adminapi_allow_to_set_permissions": "1",
+                "self_service_allowed": "1",
+            }
+        )
+
+    def test_create_integration_with_permissions_disabled(self):
+        response = self.client.create_integration(
+            name="Admin API integration",
+            integration_type="adminapi",
+            adminapi_admins=False,
+            adminapi_admins_read=False,
+            adminapi_integrations_read=False,
+            adminapi_settings_read=False,
+            adminapi_allow_to_set_permissions=False,
+        )
+
+        self.assertEqual(response['method'], 'POST')
+        self.assertEqual(response['uri'], '/admin/v3/integrations')
+        self.assertEqual(json.loads(response['body']),
+            {
+                "account_id": self.client.account_id,
+                "name": "Admin API integration",
+                "type": "adminapi",
+                "adminapi_admins": "0",
+                "adminapi_admins_read": "0",
+                "adminapi_integrations_read": "0",
+                "adminapi_settings_read": "0",
+                "adminapi_allow_to_set_permissions": "0",
+            }
+        )
+
+    def test_update_integration_with_permissions(self):
+        response = self.client.update_integration(
+            self.integration_key,
+            adminapi_admins=True,
+            adminapi_admins_read=True,
+            adminapi_info=True,
+            adminapi_integrations=True,
+            adminapi_integrations_read=True,
+            adminapi_read_log=True,
+            adminapi_read_resource=True,
+            adminapi_settings=True,
+            adminapi_settings_read=True,
+            adminapi_write_resource=True,
+            self_service_allowed=True,
+        )
+
+        self.assertEqual(response['method'], 'POST')
+        self.assertEqual(response['uri'], '/admin/v3/integrations/{}'.format(self.integration_key))
+        self.assertEqual(json.loads(response['body']),
+            {
+                "account_id": self.client.account_id,
+                "adminapi_admins": "1",
+                "adminapi_admins_read": "1",
+                "adminapi_info": "1",
+                "adminapi_integrations": "1",
+                "adminapi_integrations_read": "1",
+                "adminapi_read_log": "1",
+                "adminapi_read_resource": "1",
+                "adminapi_settings": "1",
+                "adminapi_settings_read": "1",
+                "adminapi_write_resource": "1",
+                "self_service_allowed": "1",
+            }
+        )
+
+    def test_update_integration_with_permissions_disabled(self):
+        response = self.client.update_integration(
+            self.integration_key,
+            adminapi_admins_read=False,
+            adminapi_integrations_read=False,
+            adminapi_settings_read=False,
+        )
+
+        self.assertEqual(response['method'], 'POST')
+        self.assertEqual(response['uri'], '/admin/v3/integrations/{}'.format(self.integration_key))
+        self.assertEqual(json.loads(response['body']),
+            {
+                "account_id": self.client.account_id,
+                "adminapi_admins_read": "0",
+                "adminapi_integrations_read": "0",
+                "adminapi_settings_read": "0",
+            }
+        )
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

Added new Admin API permission parameters to the `create_integration` and `update_integration` methods in the Python client:

- `adminapi_admins_read` — read-only admins permission
- `adminapi_integrations_read` — read-only integrations permission
- `adminapi_settings_read` — read-only settings permission
- `adminapi_allow_to_set_permissions` — permission to set permissions (create only)

These were added to:
- Function signatures
- Docstrings
- Request body serialization (bool → `"1"`/`"0"`)
- Integration object format documentation

## Motivation and Context

The upstream third-party repo (`trustedpath/third-party/duo_client_python`) introduced additional granular read-only permission flags for Admin API integrations. This change brings the open-source `duo_client_python` client in sync with those additions, allowing consumers to configure fine-grained read permissions when creating or updating integrations.

## How Has This Been Tested?

Added 4 new unit tests in `tests/admin/test_integration.py`:

- `test_create_integration_with_permissions` — verifies all permission params serialize as `"1"` when `True`
- `test_create_integration_with_permissions_disabled` — verifies new permission params serialize as `"0"` when `False`
- `test_update_integration_with_permissions` — verifies all permission params on update serialize as `"1"`
- `test_update_integration_with_permissions_disabled` — verifies new permission params on update serialize as `"0"`

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
