### PR TITLE
Add an option to disable CA certificate pinning

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -220,16 +220,26 @@ class Client(object):
                  paging_limit=100,
                  digestmod=hashlib.sha512,
                  sig_version=None,
-                 port=None
+                 port=None,
+                 disable_ca_pinning=False
                  ):
         """
         ca_certs - Path to CA pem file.
+        disable_ca_pinning - If True, uses the system's default trusted CA
+            certificates instead of Duo's bundled CA certificates. TLS
+            verification remains active. Cannot be used together with a
+            custom ca_certs path.
         """
         self.ikey = ikey
         self.skey = skey
         self.host = host
         self.port = port
         self.sig_timezone = sig_timezone
+        if disable_ca_pinning and ca_certs not in (None, DEFAULT_CA_CERTS):
+            raise ValueError(
+                "Cannot both disable CA pinning and provide custom CA certificates"
+            )
+        self.disable_ca_pinning = disable_ca_pinning
         if ca_certs is None:
             ca_certs = DEFAULT_CA_CERTS
         self.ca_certs = ca_certs
@@ -382,7 +392,10 @@ class Client(object):
             raise NotImplementedError('proxy_type=%s' % (self.proxy_type,))
 
         # Create outer HTTP(S) connection.
-        if self.ca_certs == 'HTTP':
+        if self.disable_ca_pinning:
+            context = ssl.create_default_context()
+            conn = http.client.HTTPSConnection(host, port, context=context)
+        elif self.ca_certs == 'HTTP':
             conn = http.client.HTTPConnection(host, port)
         elif self.ca_certs == 'DISABLE':
             kwargs = {}
@@ -634,6 +647,7 @@ def main():
     parser.add_argument('--path', required=True,
                         help='API endpoint path')
     parser.add_argument('--ca', default=DEFAULT_CA_CERTS)
+    parser.add_argument('--disable-ca-pinning', default=False)
     parser.add_argument('--sig-version', type=int, default=2)
     parser.add_argument('--sig-timezone', default='UTC')
     parser.add_argument(
@@ -655,6 +669,7 @@ def main():
         ca_certs=args.ca,
         sig_version=args.sig_version,
         sig_timezone=args.sig_timezone,
+        disable_ca_pinning=args.disable_ca_pinning,
     )
 
     params = collections.defaultdict(list)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,10 @@
 import hashlib
+import http.client
+import ssl
 from unittest import mock
 import unittest
 import duo_client.client
+import duo_client.https_wrapper
 from . import util
 import base64
 import collections
@@ -759,6 +762,87 @@ class TestInstantiate(unittest.TestCase):
             duo_client.client.Client(
                 'test_ikey', 'test_akey', 'example.com', sig_timezone='America/Detroit',
                 sig_version=3)
+
+
+class TestDisableCaPinningInit(unittest.TestCase):
+    """Tests for the disable_ca_pinning parameter on Client.__init__."""
+
+    def test_default_is_pinning_enabled(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
+        self.assertFalse(client.disable_ca_pinning)
+        self.assertEqual(client.ca_certs, duo_client.client.DEFAULT_CA_CERTS)
+
+    def test_disable_ca_pinning_true(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        disable_ca_pinning=True)
+        self.assertTrue(client.disable_ca_pinning)
+
+    def test_disable_ca_pinning_with_default_ca_certs(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        ca_certs=duo_client.client.DEFAULT_CA_CERTS, disable_ca_pinning=True)
+        self.assertTrue(client.disable_ca_pinning)
+
+    def test_disable_ca_pinning_with_none_ca_certs(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        ca_certs=None, disable_ca_pinning=True)
+        self.assertTrue(client.disable_ca_pinning)
+
+    def test_disable_ca_pinning_with_custom_ca_certs_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                   ca_certs='/path/to/custom.pem', disable_ca_pinning=True)
+        self.assertIn("Cannot both disable CA pinning", str(ctx.exception))
+
+    def test_disable_ca_pinning_with_http_ca_certs_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                   ca_certs='HTTP', disable_ca_pinning=True)
+        self.assertIn("Cannot both disable CA pinning", str(ctx.exception))
+
+    def test_disable_ca_pinning_with_disable_ca_certs_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                   ca_certs='DISABLE', disable_ca_pinning=True)
+        self.assertIn("Cannot both disable CA pinning", str(ctx.exception))
+
+
+class TestDisableCaPinningConnect(unittest.TestCase):
+    """Tests that _connect() uses the correct connection type."""
+
+    def test_connect_with_pinning_uses_cert_validating(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
+        conn = client._connect()
+        self.assertIsInstance(conn, duo_client.https_wrapper.CertValidatingHTTPSConnection)
+
+    def test_connect_with_pinning_disabled_uses_https_connection(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        disable_ca_pinning=True)
+        conn = client._connect()
+        self.assertIsInstance(conn, http.client.HTTPSConnection)
+        self.assertNotIsInstance(conn, duo_client.https_wrapper.CertValidatingHTTPSConnection)
+
+    def test_connect_with_pinning_disabled_has_verification_enabled(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        disable_ca_pinning=True)
+        conn = client._connect()
+        self.assertEqual(conn._context.verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(conn._context.check_hostname)
+
+    def test_connect_with_pinning_disabled_uses_system_ca(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        disable_ca_pinning=True)
+        conn = client._connect()
+        default_ctx = ssl.create_default_context()
+        self.assertEqual(
+            conn._context.verify_mode, default_ctx.verify_mode)
+        self.assertEqual(
+            conn._context.check_hostname, default_ctx.check_hostname)
+
+    def test_connect_with_pinning_enabled_default(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
+        conn = client._connect()
+        self.assertIsInstance(conn, duo_client.https_wrapper.CertValidatingHTTPSConnection)
+        self.assertEqual(conn.default_ssl_context.verify_mode, ssl.CERT_REQUIRED)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
- Added `disable_ca_pinning=False` parameter to `Client.__init__()`
- Added validation that raises `ValueError` if both `disable_ca_pinning=True` and a custom `ca_certs` path are provided
- Added a new branch in `_connect()` that, when `disable_ca_pinning` is enabled, creates an `http.client.HTTPSConnection` with `ssl.create_default_context()` instead of using `CertValidatingHTTPSConnection` with the bundled CA bundle
- Added `--disable-ca-pinning` argument to the CLI `main()` entry point

## How Has This Been Tested?
- `TestDisableCaPinningInit` — 7 tests verifying constructor behavior:
    - Default value is `False` and uses bundled CA certs
    - Can be set to `True` with default or `None` ca_certs
    - Raises `ValueError` when combined with a custom `ca_certs` path
    - Raises `ValueError` when combined with `ca_certs='HTTP'`
    - Raises `ValueError` when combined with `ca_certs='DISABLE'`
- `TestDisableCaPinningConnect` — 5 tests verifying connection behavior:
    - Default client uses `CertValidatingHTTPSConnection` (pinned)
    - Disabled pinning uses `http.client.HTTPSConnection` (not pinned)
    - Disabled pinning still has `ssl.CERT_REQUIRED` and `check_hostname=True`
    - Disabled pinning SSL context matches `ssl.create_default_context()` settings
    - Default client has `CERT_REQUIRED` on its custom SSL context

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
