### PR TITLE
Add CA bundle version and pinning status to the user agent string

### DIFF
--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -248,7 +248,7 @@ class Client(object):
         if user_agent:
             self.user_agent = (
                 f"{user_agent} ca_bundle/{CA_BUNDLE_VERSION}"
-                f" ca_pinning/{ca_pinning_status}"
+                f" (ca_pinning={ca_pinning_status})"
             )
         else:
             self.user_agent = user_agent

--- a/duo_client/client.py
+++ b/duo_client/client.py
@@ -36,6 +36,7 @@ except ImportError as e:
 from .https_wrapper import CertValidatingHTTPSConnection
 
 DEFAULT_CA_CERTS = os.path.join(os.path.dirname(__file__), 'ca_certs.pem')
+CA_BUNDLE_VERSION = '1.0'
 
 
 def canon_params(params):
@@ -243,7 +244,14 @@ class Client(object):
         if ca_certs is None:
             ca_certs = DEFAULT_CA_CERTS
         self.ca_certs = ca_certs
-        self.user_agent = user_agent
+        ca_pinning_status = 'disabled' if disable_ca_pinning else 'enabled'
+        if user_agent:
+            self.user_agent = (
+                f"{user_agent} ca_bundle/{CA_BUNDLE_VERSION}"
+                f" ca_pinning/{ca_pinning_status}"
+            )
+        else:
+            self.user_agent = user_agent
         self.set_proxy(host=None, proxy_type=None)
         self.paging_limit = paging_limit
         self.digestmod = digestmod

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -818,19 +818,19 @@ class TestUserAgent(unittest.TestCase):
 
     def test_default_user_agent_includes_ca_pinning_enabled(self):
         client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
-        self.assertIn("ca_pinning/enabled", client.user_agent)
+        self.assertIn("(ca_pinning=enabled)", client.user_agent)
 
     def test_user_agent_includes_ca_pinning_disabled(self):
         client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
                         disable_ca_pinning=True)
-        self.assertIn("ca_pinning/disabled", client.user_agent)
+        self.assertIn("(ca_pinning=disabled)", client.user_agent)
 
     def test_default_user_agent_format(self):
         client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
         expected = (
             f"Duo API Python/{duo_client.client.__version__}"
             f" ca_bundle/{duo_client.client.CA_BUNDLE_VERSION}"
-            f" ca_pinning/enabled"
+            f" (ca_pinning=enabled)"
         )
         self.assertEqual(client.user_agent, expected)
 
@@ -840,7 +840,7 @@ class TestUserAgent(unittest.TestCase):
         expected = (
             f"MyApp/1.0"
             f" ca_bundle/{duo_client.client.CA_BUNDLE_VERSION}"
-            f" ca_pinning/enabled"
+            f" (ca_pinning=enabled)"
         )
         self.assertEqual(client.user_agent, expected)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -806,6 +806,50 @@ class TestDisableCaPinningInit(unittest.TestCase):
         self.assertIn("Cannot both disable CA pinning", str(ctx.exception))
 
 
+class TestUserAgent(unittest.TestCase):
+    """Tests for user agent string including CA bundle version and pinning status."""
+
+    def test_default_user_agent_includes_ca_bundle_version(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
+        self.assertIn(
+            f"ca_bundle/{duo_client.client.CA_BUNDLE_VERSION}",
+            client.user_agent,
+        )
+
+    def test_default_user_agent_includes_ca_pinning_enabled(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
+        self.assertIn("ca_pinning/enabled", client.user_agent)
+
+    def test_user_agent_includes_ca_pinning_disabled(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        disable_ca_pinning=True)
+        self.assertIn("ca_pinning/disabled", client.user_agent)
+
+    def test_default_user_agent_format(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com')
+        expected = (
+            f"Duo API Python/{duo_client.client.__version__}"
+            f" ca_bundle/{duo_client.client.CA_BUNDLE_VERSION}"
+            f" ca_pinning/enabled"
+        )
+        self.assertEqual(client.user_agent, expected)
+
+    def test_custom_user_agent_includes_ca_fields(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        user_agent='MyApp/1.0')
+        expected = (
+            f"MyApp/1.0"
+            f" ca_bundle/{duo_client.client.CA_BUNDLE_VERSION}"
+            f" ca_pinning/enabled"
+        )
+        self.assertEqual(client.user_agent, expected)
+
+    def test_empty_user_agent_not_modified(self):
+        client = duo_client.client.Client('ikey', 'skey', 'host.example.com',
+                        user_agent='')
+        self.assertEqual(client.user_agent, '')
+
+
 class TestDisableCaPinningConnect(unittest.TestCase):
     """Tests that _connect() uses the correct connection type."""
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Added `CA_BUNDLE_VERSION = '1.0'` constant in `duo_client/client.py`
  - Modified `Client.__init__` to append `ca_bundle/{version}` and `(ca_pinning={enabled|disabled})` to the user agent string based on the `disable_ca_pinning` runtime state
  - Empty/falsy user agent strings are left unmodified

## How Has This Been Tested?
  - `test_default_user_agent_includes_ca_bundle_version` — verifies `ca_bundle/1.0` is present in the default user agent
  - `test_default_user_agent_includes_ca_pinning_enabled` — verifies `(ca_pinning=enabled)` when pinning is not disabled
  - `test_user_agent_includes_ca_pinning_disabled` — verifies `(ca_pinning=disabled)` when `disable_ca_pinning=True`
  - `test_default_user_agent_format` — asserts the full expected user agent string format
  - `test_custom_user_agent_includes_ca_fields` — verifies CA fields are appended to custom user agent strings
  - `test_empty_user_agent_not_modified` — verifies an empty user agent is not modified

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
